### PR TITLE
Added the ability to toggle interactive via the status indicators

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -15,10 +15,10 @@
                 <i class="fa fa-bars" aria-hidden="true"></i>
             </a>
         </div>
-        <div class="interactive-status" style="display:none">
+        <div class="interactive-status interactive-connector">
             Interactive
         </div>
-        <div class="chat-status" style="display:none">
+        <div class="chat-status interactive-connector">
             Chat
         </div>
         <div class="updated-version" style="display:none">

--- a/gui/js/global.js
+++ b/gui/js/global.js
@@ -27,7 +27,7 @@ function pageNavigation(){
         $.sidr('close','main-menu');
 
         // If the selected page is 
-        if (nextup !== "start" && nextup !== "login" && nextup !== "updates"){
+        if (nextup !== "login" && nextup !== "updates"){
             $('.interactive-status, .chat-status').fadeIn('fast');
         } else {
             $('.interactive-status, .chat-status').fadeOut('fast');

--- a/lib/interactive/beam-connect.js
+++ b/lib/interactive/beam-connect.js
@@ -104,6 +104,7 @@ function beamDisconnect(event){
 
         // Send to UI
         event.sender.send('beamInteractive', 'disconnected');
+        console.log("Interactive is now disconnected!");
 
         // Update interactive status in json
         var dbSettings = new JsonDB('./user-settings/settings', true, false);
@@ -128,7 +129,7 @@ ipcMain.on('beamInteractive', function(event, status) {
 
 
 // Global Killswitch
-// When Ctrl+Backspace is pressed check interactive status, then send event to render process to flip ui.
+// When Ctrl+ALT+F12 is pressed check interactive status, then send event to render process to flip ui.
 function shortcutRegister(){
     globalShortcut.register('CommandOrControl+Alt+F12', () => {
         try{


### PR DESCRIPTION
Added the ability to toggle interactive via the status indicators, added a console log line to confirm interactive disconnection, made the chat/interactive status indicators visible on the main page again and changed the source comment about Global Killswitch CTRL+Backspace to CTRL+ALT+F12.