### PR TITLE
Enable mouse buttons to be specified for a game control button

### DIFF
--- a/gui/js/interactive/controls-editor.js
+++ b/gui/js/interactive/controls-editor.js
@@ -733,7 +733,10 @@ function gameAutoComplete(){
         "numpad_6",
         "numpad_7",
         "numpad_8",
-        "numpad_9"
+        "numpad_9",
+        "leftmouse",
+        "middlemouse",
+        "rightmouse"
     ];
 
     return availableButtons;

--- a/lib/interactive/handlers/game-controls/emulator.js
+++ b/lib/interactive/handlers/game-controls/emulator.js
@@ -10,16 +10,23 @@ function keyTap(key){
     var keyJson = keyTranslator.translate(key);
     var key = keyJson.key;
     var emulator = keyJson.emulator;
+    var isMouseClick = keyJson.isMouseClick;
 
     // Check the emulator and process key.
     if(emulator == "KBMRobot"){
         // Press as KBMRobot
         try{
             console.log('KBMRobot: Tapped '+key);
-            kbmRobot.press(key)
-                    .sleep(100)
-                    .release(key)
-                    .go();
+            // Special check for mouse clicks
+            if(isMouseClick === true) {     
+              kbmRobot.mouseClick(key)
+                      .go();     
+            } else {
+              kbmRobot.press(key)
+                      .sleep(100)
+                      .release(key)
+                      .go();
+           }
         }catch(err){
             renderWindow.webContents.send('error', "There was an error trying to press button: "+key);
         }
@@ -27,7 +34,12 @@ function keyTap(key){
         // Press as robotjs.
         try{
             console.log('Robotjs: Tapped '+key);
-            robotjs.keyTap(key);
+            // Special check for mouse clicks
+            if(isMouseClick === true) {   
+              robotjs.mouseClick(key);     
+            } else {
+              robotjs.keyTap(key);
+            }
         }catch(err){
             renderWindow.webContents.send('error', "There was an error trying to press button: "+key);
         }
@@ -39,22 +51,35 @@ function keyHolding(key, state){
     var keyJson = keyTranslator.translate(key);
     var key = keyJson.key;
     var emulator = keyJson.emulator;
+    var isMouseClick = keyJson.isMouseClick;
 
     // Check the emulator and process key.
     if(emulator == "KBMRobot"){
         if(state == "down"){
             try{
                 console.log('KBMRobot: Held '+key);
-                kbmRobot.press(key)
-                        .go();
+                // Special check for mouse clicks
+                if(isMouseClick === true) {
+                  kbmRobot.mousePress(key)
+                          .go();
+                } else {
+                  kbmRobot.press(key)
+                          .go();
+                }
             }catch(err){
                 renderWindow.webContents.send('error', "There was an error trying to press button: "+key);
             }
         } else {
             try{
                 console.log('KBMRobot: Released '+key);
-                kbmRobot.release(key)
-                        .go();
+                // Special check for mouse clicks
+                if(isMouseClick === true) {
+                  kbmRobot.mouseRelease(key)
+                          .go();
+                } else {
+                  kbmRobot.release(key)
+                          .go();
+                }
             }catch(err){
                 renderWindow.webContents.send('error', "There was an error trying to press button: "+key);
             }
@@ -62,7 +87,15 @@ function keyHolding(key, state){
     } else {
         try{
             console.log('Robotjs: Toggled '+key+' '+state+'.');
-            robotjs.keyToggle(key, state);
+            // Special check for mouse clicks
+            if(isMouseClick === true) {
+              // Oddly, the key and state args are reversed compared to the
+              // the keyToggle call
+              robotjs.mouseToggle(state, key);
+            } else {
+              robotjs.keyToggle(key, state);
+            }
+            
         }catch(err){
             renderWindow.webContents.send('error', "There was an error trying to press button: "+key);
         }

--- a/lib/interactive/handlers/game-controls/keytranslator.js
+++ b/lib/interactive/handlers/game-controls/keytranslator.js
@@ -12,6 +12,10 @@ var keyTranslator = function(key){
 		var keyHandler = "Robotjs";
 	}
 	
+	
+	//normalize key string
+	var key = key.toLowerCase();
+	
 	// Check whether or not this key press should be a mouse click.
 	var isMouseClick = 
 		(key === "leftmouse" || key === "middlemouse" || key === "rightmouse");
@@ -19,10 +23,8 @@ var keyTranslator = function(key){
 	// Robot JS
 	// Other than mouse clicks, there's currently no need to translate for robotjs. 
 	// This is the default handler.
-	if(keyHandler == "Robotjs" || keyHandler === null || keyHandler === undefined){	
+	if(keyHandler == "Robotjs" || keyHandler === null || keyHandler === undefined){
 		
-		//normalize key string and check for special mouse actions
-		var key = key.toLowerCase();
 		switch (key){
 			case "leftmouse": 
 				var key = "left"

--- a/lib/interactive/handlers/game-controls/keytranslator.js
+++ b/lib/interactive/handlers/game-controls/keytranslator.js
@@ -12,8 +12,7 @@ var keyTranslator = function(key){
 		var keyHandler = "Robotjs";
 	}
 	
-	
-	//normalize key string
+	// Normalize key string
 	var key = key.toLowerCase();
 	
 	// Check whether or not this key press should be a mouse click.

--- a/lib/interactive/handlers/game-controls/keytranslator.js
+++ b/lib/interactive/handlers/game-controls/keytranslator.js
@@ -11,11 +11,29 @@ var keyTranslator = function(key){
 	} catch (err){
 		var keyHandler = "Robotjs";
 	}
-
+	
+	// Check whether or not this key press should be a mouse click.
+	var isMouseClick = 
+		(key === "leftmouse" || key === "middlemouse" || key === "rightmouse");
+	
 	// Robot JS
-	// Currently, no need to translate for robotjs. It is the default handler.
-	if(keyHandler == "Robotjs" || keyHandler === null || keyHandler === undefined){
-
+	// Other than mouse clicks, there's currently no need to translate for robotjs. 
+	// This is the default handler.
+	if(keyHandler == "Robotjs" || keyHandler === null || keyHandler === undefined){	
+		
+		//normalize key string and check for special mouse actions
+		var key = key.toLowerCase();
+		switch (key){
+			case "leftmouse": 
+				var key = "left"
+				break;
+			case "middlemouse":
+				var key = "middle"
+				break;
+			case "rightmouse":
+				var key = "right";
+				break;
+		}
 	}
 
 	// KBM Robot
@@ -71,11 +89,20 @@ var keyTranslator = function(key){
 			case "NUMPAD 9":
 				var key = "KP_9";
 				break;
+			case "LEFTMOUSE": 
+				var key = "1";
+				break;
+			case "MIDDLEMOUSE":
+				var key = "2";
+				break;
+			case "RIGHTMOUSE":
+				var key = "3";
+				break;
 		}
 	}
 
 	// Send correct key name back.
-	return {key: key, emulator:keyHandler};
+	return {key: key, emulator:keyHandler, isMouseClick: isMouseClick};
 }
 
 // Exports


### PR DESCRIPTION
I wanted an interactive button to be able to click my mouse but I didn't see the option to do so and I didn't want to give full joystick control to the viewers either (however at a quick glance, it doesn't look like joysticks can or do support mouse clicks anyhow).

I updated my fork to add this feature and wasn't sure if this is something you want in the main repro but I figured I'd toss this up anyway and see what you think. It covers both emulators, single press/holding cases, and updates the autocomplete list. 

For the end user, this allows them to input: "leftmouse", "middlemouse", and "rightmouse" as a key for a Game Control button. 

My use case: I currently play a lot of PlayerUnknown's Battlegrounds and thought it would be fun to allow viewers to occasionally fire my weapon at random, potentially revealing my position to enemy players.

