### PR TITLE
Imageoverlay size handling

### DIFF
--- a/gui/js/interactive/controls-editor.js
+++ b/gui/js/interactive/controls-editor.js
@@ -718,11 +718,13 @@ function showImageSettings(uniqueid){
 
         <div class="effect-specific-title"><h4>How big should it be?</h4></div>
         <div class="input-group">
-            <span class="input-group-addon" id="image-size-type">Size (in percent)</span>
-            <input type="text" class="form-control" id="image-size-setting" aria-describeby="image-size-setting-type" type="number">
+            <span class="input-group-addon" id="image-size-type">Height (in pixels)</span>
+            <input type="text" class="form-control" id="image-height-setting" aria-describeby="image-height-setting-type" type="number">
+            <span class="input-group-addon" id="image-size-type">Width (in pixels)</span>
+            <input type="text" class="form-control" id="image-width-setting" aria-describeby="image-width-setting-type" type="number">
         </div>
         <div class="effect-info">
-            Just put the number in this field, do not enter the percent sign.
+            Just put the numbers in these fields. If left blank both height and width will be set to 100px as a failsafe.
         </div>
 
         <div class="effect-specific-title"><h4>How long should it show?</h4></div>
@@ -980,9 +982,10 @@ function saveControls(){
         case "Show Image":
             var imageFile = $(this).find('.show-image-effect-input').val();
             var imagePlacement = $(this).find('.image-placement-effect-type').text();
-            var imageSize = $(this).find('#image-size-setting').val();
+            var imageHeight = $(this).find('#image-height-setting').val();
+            var imageWidth = $(this).find('#image-width-setting').val();
             var imageLength = $(this).find('#image-length-setting').val();
-            dbControls.push('./firebot/controls/'+controlID+'/effects/'+i, {"type": "Show Image", "file": imageFile, "position": imagePlacement, "size": imageSize, "length": imageLength});
+            dbControls.push('./firebot/controls/'+controlID+'/effects/'+i, {"type": "Show Image", "file": imageFile, "position": imagePlacement, "height": imageHeight, "width": imageWidth , "length": imageLength});
             break;
         }
         i++
@@ -1112,7 +1115,8 @@ function loadSettings(controlId, button){
             case "Show Image":
                 $('.panel'+uniqueid+' .show-image-effect-input').val(effect.file);
                 $('.panel'+uniqueid+' .image-placement-effect-type').text(effect.position);
-                $('.panel'+uniqueid+' #image-size-setting').val(effect.size);
+                $('.panel'+uniqueid+' #image-height-setting').val(effect.height);
+                $('.panel'+uniqueid+' #image-width-setting').val(effect.width);
                 $('.panel'+uniqueid+' #image-length-setting').val(effect.length);
                 break;
             }

--- a/gui/js/interactive/handler/mediaHandler.js
+++ b/gui/js/interactive/handler/mediaHandler.js
@@ -29,7 +29,8 @@ function playSound(data){
 function showImage(data){
     var filepath = data.filepath;
     var imagePosition = data.imagePosition;
-    var imageSize = data.imageSize;
+    var imageHeight = data.imageHeight;
+    var imageWidth = data.imageWidth;
     var imageDuration = parseInt(data.imageDuration);
 
     var dbSettings = new JsonDB("./user-settings/settings", true, false);
@@ -59,6 +60,6 @@ function showImage(data){
     }
 
     // Compile data and send to overlay.
-    var data = {"event":"image","filepath":filepath, "imagePosition":imagePosition, "imageSize":imageSize, "imageDuration":imageDuration};
+    var data = {"event":"image","filepath":filepath, "imagePosition":imagePosition, "imageHeight":imageHeight, "imageWidth": imageWidth, "imageDuration":imageDuration};
     broadcast(data);
 }

--- a/gui/js/interactive/handler/mediaHandler.js
+++ b/gui/js/interactive/handler/mediaHandler.js
@@ -39,8 +39,11 @@ function showImage(data){
     if(imagePosition == "" || imagePosition === null){
         var imageX = "Top Middle";
     }
-    if(imageSize == "" || imageSize === null){
-        var imageSize = "100";
+    if(imageHeight == "" || imageHeight === null){
+        var imageHeight = "100";
+    }
+    if(imageWidth == "" || imageWidth === null){
+        var imageWidth = "100";
     }
     if(imageDuration == "" || imageDuration === null){
         var imageDuration = 5;

--- a/lib/interactive/handlers/mediaProcessor.js
+++ b/lib/interactive/handlers/mediaProcessor.js
@@ -43,11 +43,12 @@ function imageProcessor(effect){
     // They have an image loaded up for this one.
     var filepath = effect.file;
     var imagePosition = effect.position;
-    var imageSize = effect.size;
+    var imageHeight = effect.height;
+    var imageWidth = effect.width;
     var duration = effect.length;
 
     // Send data back to media.js in the gui.
-    var data = {"filepath": filepath, "imagePosition": imagePosition, "imageSize": imageSize, "imageDuration": duration};
+    var data = {"filepath": filepath, "imagePosition": imagePosition, "imageHeight": imageHeight, "imageWidth": imageWidth, "imageDuration": duration};
     renderWindow.webContents.send('showimage', data);
 }
 

--- a/overlay/js/main.js
+++ b/overlay/js/main.js
@@ -74,14 +74,15 @@ function showImage(data){
 	var filepath = data.filepath;
 	var filepathNew = filepath.replace(/\\/g,"/");
 	var imagePosition = data.imagePosition;
-	var imageSize = data.imageSize;
+	var imageHeight = data.imageHeight;
+	var imageWidth = data.imageWidth;
 	var imageDuration = parseInt(data.imageDuration) * 1000;
 
 	// Get time in milliseconds to use as class name.
 	var d = new Date();
 	var divClass = d.getTime();
 
-	var imageFinal = '<div class="'+divClass+'-image imageOverlayContainer" style="display:none;"><img class="imageOverlay" position="'+imagePosition+'" src="'+filepathNew+'?time='+divClass+'" style="width:'+ imageSize +'%;vertical-align: middle;"></div>';
+	var imageFinal = '<div class="'+divClass+'-image imageOverlayContainer" style="display:none;"><img class="imageOverlay" position="'+imagePosition+'" src="'+filepathNew+'?time='+divClass+'" style="height:'+ imageHeight +'px;width:'+ imageWidth +'px;"></div>';
 	
 	$('#wrapper').append(imageFinal);
 	$('.'+divClass+'-image').fadeIn('fast');


### PR DESCRIPTION
This should handle #168, and if the streamer leaves the size fields blank the image will be forced to 100x100px as a failsafe. The only downside I see with this method is that they have to know the pixel size of the images to get the proportions right. Might have to look into doing this another way at some point, maybe require the pixel size of the imagefile  then have a percent field that can be used with a jquery function to scale the image while keeping the correct proportions.

The way I added image size controls in the first place was flawed as it was giving images the whole container div as a "playground" which blew them up in all directions. Rewrote it to require pixel sizes for now.