### PR TITLE
Cooldown saving.

### DIFF
--- a/lib/interactive/control-router.js
+++ b/lib/interactive/control-router.js
@@ -19,45 +19,37 @@ function controlRouter(mouseevent, mixerControls, mixerControl, gameJson, inputE
       username = participant.username;
     }
 
-    // Log input event.
-    //console.log(inputEvent);
-    //console.log(participant);
-    //console.log(control);
+    // Create request wrapper (instead of having to pass in a ton of args)
+    var processEffectsRequest = {
+        effects: effects,
+        firebot: firebot,
+        participant: participant,
+        control: control,
+        isManual: false
+    } 
 
     // Check to see if this is a mouse down or mouse up event.
     if(mouseevent == "mousedown"){
         // Mouse Down event called.
 
-        // Cooldown Button or Buttons
-        cooldown.router(mixerControls, mixerControl, firebot, control, function(response){
-                  
-          // Throw this information into the moderation panel.
-          renderWindow.webContents.send('eventlog', {username: participant.username, event: "pressed the "+controlID+" button."});
+        // Make sure cooldown is processed.
+        cooldown.router(mixerControls, mixerControl, firebot, control)
+        .then((res) => autoPlay(processEffectsRequest))
+        .then(() => {
+            // Charge sparks for the button that was pressed.
+            if (inputEvent.transactionID) {
+                // This will charge the user.
+                mixerInteractive.sparkTransaction(inputEvent.transactionID);
+            };
+        })
+        .then(() => {
+            // Throw this button info into UI log.
+            renderWindow.webContents.send('eventlog', {username: participant.username, event: "pressed the "+controlID+" button."});
+        })
 
-          // Charge sparks for the button that was pressed.
-          if (inputEvent.transactionID) {
-              // This will charge the user.
-              mixerInteractive.sparkTransaction(inputEvent.transactionID);
-          };
-          
-          // Create request wrapper (instead of having to pass in a ton of args)
-          var processEffectsRequest = {
-            effects: effects,
-            firebot: firebot,
-            participant: participant,
-            control: control,
-            isManual: false
-          }        
-          
-          // Run the effects
-          effectRunner.processEffects(processEffectsRequest)
-            .then(function() {
-              // This is called after the effects are done running. 
-            });
-
-        }) // end cooldown function
     } else {
-        // Mouse up event called.
+        // Mouse up event called. 
+        // Right now this is only used by game controls to know when to lift keys up.
 
         // Loop through effects for this button.
         for (var item in effects){
@@ -70,6 +62,16 @@ function controlRouter(mouseevent, mixerControls, mixerControl, gameJson, inputE
             }
         }
     }
+}
+
+// Auto Play
+// This function will activate a button when triggered through mixer..
+function autoPlay(processEffectsRequest){
+    // Run the effects
+    effectRunner.processEffects(processEffectsRequest)
+    .then(function() {
+        // This is called after the effects are done running. 
+    });
 }
 
 // Manual Play

--- a/lib/interactive/cooldowns.js
+++ b/lib/interactive/cooldowns.js
@@ -1,48 +1,65 @@
 const JsonDB = require('node-json-db');
 const mixerInteractive = require('./mixer-interactive.js');
 
+// This var will save the cooldown status of all buttons.
+cooldownSaved = []
+
 // Cooldown Router
-function cooldownRouter(mixerControls, mixerControl, firebot, control, callback){
-    var cooldown = control.cooldown;
-    var groupName = control.cooldownGroup;
+function cooldownRouter(mixerControls, mixerControl, firebot, control){
+    return new Promise((resolve, reject) => {
+        var cooldown = control.cooldown;
+        var groupName = control.cooldownGroup;
 
-    if(groupName !== undefined && groupName !== ""){
-        // This button has a cooldown group... so it's time to cool them all down.
-        var groupsJson = firebot.cooldownGroups[groupName];
+        if(groupName !== undefined && groupName !== ""){
+            // This button has a cooldown group... so it's time to cool them all down.
+            var groupsJson = firebot.cooldownGroups[groupName];
 
-        // This will error out if the cooldown group this button is assigned to no longer exists.
-        try{
-            var buttons = groupsJson.buttons;
-            var cooldown = parseInt( groupsJson['length'] ) * 1000;
+            try{
+                // This will error out if the cooldown group this button is assigned to no longer exists.
+                var buttons = groupsJson.buttons;
+                var cooldown = parseInt( groupsJson['length'] ) * 1000;
 
-            // For each button in the cooldown group...
-            groupCooldown(buttons, cooldown, firebot)
-        }catch(err){
-            // This cooldown group was deleted. Fix this control.
-            var dbSettings = new JsonDB("./user-settings/settings", true, true);
-            var gameName = dbSettings.getData('/interactive/lastBoard');
-            var dbControls = new JsonDB("./user-settings/controls/"+gameName, true, true);
-            dbControls.delete('./firebot/controls/'+control.controlId+'/cooldownGroup');
+                // For each button in the cooldown group...
+                groupCooldown(buttons, cooldown, firebot)
 
-            // Let's check to see if this one button needs to cool down then...
+                // Resolve
+                resolve(true);
+            }catch(err){
+                // This cooldown group was deleted. Fix this control.
+                var dbSettings = new JsonDB("./user-settings/settings", true, true);
+                var gameName = dbSettings.getData('/interactive/lastBoard');
+                var dbControls = new JsonDB("./user-settings/controls/"+gameName, true, true);
+                dbControls.delete('./firebot/controls/'+control.controlId+'/cooldownGroup');
+
+                // Let's check to see if this one button needs to cool down then...
+                if (cooldown !== undefined && cooldown > 0){
+                    var cooldown = parseInt(control.cooldown) * 1000;
+                    var cooldownCheck = cooldownChecker(control.controlID, cooldown);
+                    if(cooldownCheck === true){
+                        mixerControl.setCooldown(cooldown);
+                    }
+                }
+
+                // Resolve
+                resolve(true);
+            }
+            
+        } else {
+            // Button doesn't have a cooldown group, so let's just cool down this one button.
+
+            // If cooldown is not listed or zero, then don't do anything.
             if (cooldown !== undefined && cooldown > 0){
                 var cooldown = parseInt(control.cooldown) * 1000;
-                mixerControl.setCooldown(cooldown);
+                var cooldownCheck = cooldownChecker(control.controlID, cooldown);
+                if(cooldownCheck === true){
+                    mixerControl.setCooldown(cooldown);
+                }
             }
-        }
-        
-    } else {
-        // Button doesn't have a cooldown group, so let's just cool down this one button.
 
-        // If cooldown is not listed or zero, then don't do anything.
-        if (cooldown !== undefined && cooldown > 0){
-            var cooldown = parseInt(control.cooldown) * 1000;
-            mixerControl.setCooldown(cooldown);
+            // Resolve
+            resolve(true);
         }
-    }
-
-    // Callback
-    callback('finished');
+    });
 }
 
 // Group Cooldown
@@ -51,13 +68,40 @@ function groupCooldown(buttons, cooldown, firebot){
     
     // Loop through and find button to cool down.
     for(button of buttons){
-        var buttonJson = firebot.controls[button];
-        var scene = buttonJson.scene;
-        mixerInteractive.returnButton(button, scene)
-        .then((control) => {
-            console.log('Cooling Down: '+ control.controlID);
-            control.setCooldown(cooldown);
-        })
+       var cooldownCheck = cooldownChecker(button, cooldown);
+       if(cooldownCheck === true){
+            var buttonJson = firebot.controls[button];
+            var scene = buttonJson.scene;
+            mixerInteractive.returnButton(button, scene)
+            .then((control) => {
+                console.log('Cooling Down: '+ control.controlID);
+                control.setCooldown(cooldown);
+            })
+       }
+    }
+}
+
+// Cooldown Checker
+// This function checks to see if a button should be cooled down or not based on current cooldown count. 
+// It will return true if the new cooldown is longer than what is was already.
+function cooldownChecker(buttonID, cooldown){
+    // Get current time in milliseconds
+    var dateNow = Date.now();
+
+    // Add cooldown amount to current time. Save to var newTime.
+    var newTime = dateNow + cooldown;
+
+    // Go look into cooldownSaved for this button. Save to var oldTime.
+    var oldTime = cooldownSaved[buttonID];
+
+    // If new time is bigger than oldTime resolve true, else false.
+    if(oldTime === undefined || newTime > oldTime){
+        // Push new value and resolve.
+        cooldownSaved[buttonID] = newTime;
+        return true;
+    } else {
+        // Keep old time.
+        return false;
     }
 }
 

--- a/lib/interactive/handlers/cooldownProcessor.js
+++ b/lib/interactive/handlers/cooldownProcessor.js
@@ -1,12 +1,12 @@
-const cooldown = require('../cooldowns.js');
+const mixerCooldown = require('../cooldowns.js');
 
 // Cooldown Processor
 // Gets the cooldown info of the button and then sends it off to cool them all down.
 function cooldownProcessor(effect, firebot){
-    var cooldownButtons = effect.buttons;
-    var cooldownLength = parseInt( effect['length'] ) * 1000;
+    var buttons = effect.buttons;
+    var cooldown = parseInt( effect['length'] ) * 1000;
 
-    cooldown.group(cooldownButtons, cooldownLength, firebot)
+    mixerCooldown.group(buttons, cooldown, firebot)
 }
 
 


### PR DESCRIPTION
Addresses #167 

Cooldowns are now only applied if the new cooldown amount would make people wait longer than the current cooldown.

For example, if someone hits a button that cools something down for 3 minutes. You can no longer hit another button that would change that to, say, 10 seconds. This helps when you have multiple different ways to cool down a button. The app will pick whatever wait is longest.