### PR TITLE
Replacing button dropdowns, ui changes.

### DIFF
--- a/gui/css/main.css
+++ b/gui/css/main.css
@@ -3677,11 +3677,15 @@
   margin-top: 1em;
 }
 /* line 24, ../scss/_interactive.scss */
-.functionality-settings .effect-info {
+.functionality-settings .effect-setting-container {
   padding: .5em 0em;
 }
+/* line 27, ../scss/_interactive.scss */
+.functionality-settings .effect-info {
+  margin: 1em 0em;
+}
 
-/* line 32, ../scss/_interactive.scss */
+/* line 35, ../scss/_interactive.scss */
 #board-settings .board-group-defaults-settings .board-group .board-group-scene {
   background-color: #007eff;
   padding: .5em;
@@ -3690,7 +3694,7 @@
   font-weight: bold;
   border-radius: .5em .5em 0em 0em;
 }
-/* line 40, ../scss/_interactive.scss */
+/* line 43, ../scss/_interactive.scss */
 #board-settings .board-group-defaults-settings .board-group .board-group-scene-dropdown {
   background-color: #0e162a;
   padding: .5em;
@@ -3698,18 +3702,18 @@
   border-radius: 0em 0em .5em .5em;
 }
 
-/* line 50, ../scss/_interactive.scss */
+/* line 53, ../scss/_interactive.scss */
 .playbutton {
   background: none;
   border: none;
   font-size: 2em;
 }
-/* line 54, ../scss/_interactive.scss */
+/* line 57, ../scss/_interactive.scss */
 .playbutton:hover {
   color: #adadad;
 }
 
-/* line 59, ../scss/_interactive.scss */
+/* line 62, ../scss/_interactive.scss */
 .ui-autocomplete {
   border-radius: 10px;
   padding: 5px;
@@ -3724,30 +3728,51 @@
   height: 150px;
   overflow-y: scroll;
 }
-/* line 72, ../scss/_interactive.scss */
+/* line 75, ../scss/_interactive.scss */
 .ui-autocomplete li {
   cursor: pointer;
 }
-/* line 74, ../scss/_interactive.scss */
+/* line 77, ../scss/_interactive.scss */
 .ui-autocomplete li div {
   padding: 5px;
   margin: 2px;
 }
-/* line 79, ../scss/_interactive.scss */
+/* line 82, ../scss/_interactive.scss */
 .ui-autocomplete li:hover {
   color: white;
   background-color: #007eff;
 }
 
-/* line 85, ../scss/_interactive.scss */
+/* line 88, ../scss/_interactive.scss */
 .ui-helper-hidden-accessible {
   display: none;
 }
 
-/* line 89, ../scss/_interactive.scss */
+/* line 92, ../scss/_interactive.scss */
 .board-group-defaults-settings, .board-cooldown-groups, .interactive-button-holder.active {
   display: flex;
   flex-wrap: wrap;
+}
+
+/* line 97, ../scss/_interactive.scss */
+.cooldown-group-buttons {
+  height: 200px;
+  overflow: hidden;
+  overflow-y: scroll;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 6px 12px;
+  margin: 10px 0px;
+}
+/* line 106, ../scss/_interactive.scss */
+.cooldown-group-buttons .cooldown-group-button-option {
+  border-bottom: 1px solid #cecece;
+  padding: 6px 0px;
+}
+/* line 110, ../scss/_interactive.scss */
+.cooldown-group-buttons .cooldown-group-button-option input {
+  transform: scale(2);
+  margin: 6px;
 }
 
 /* line 3, ../scss/_groups.scss */

--- a/gui/index.html
+++ b/gui/index.html
@@ -569,13 +569,10 @@
 
                   <div class="cooldown-group-button-container">
                     <h3>Which buttons should cool down together?</h3>
-                    <div class="btn-group">
-                        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <span class="cooldown-group-type">Pick One</span> <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu cooldown-group-dropdown"></ul>
+                    <div class="cooldown-group-buttons"></div>
+                    <div class="cooldown-group-button-reset">
+                      <button class="btn btn-warning">Uncheck all</button>
                     </div>
-                    <div class="selected-cooldown-group-buttons"></div>
                   </div>
 
                 </div>

--- a/gui/js/interactive/controls-editor.js
+++ b/gui/js/interactive/controls-editor.js
@@ -75,6 +75,7 @@ function addMoreFunctionality(uniqueid){
                             <li><a href="#" uniqueid="${uniqueid}" effect="Chat">Chat</a></li>
                             <li><a href="#" uniqueid="${uniqueid}" effect="Cooldown">Cooldown</a></li>
                             <li><a href="#" uniqueid="${uniqueid}" effect="Celebration">Celebration</a></li>
+                            <li><a href="#" uniqueid="${uniqueid}" effect="Delay">Delay</a></li>
                             <li><a href="#" uniqueid="${uniqueid}" effect="Dice">Dice</a></li>
                             <li><a href="#" uniqueid="${uniqueid}" effect="Game Control">Game Control</a></li>
                             <li><a href="#" uniqueid="${uniqueid}" effect="HTML">HTML</a></li>
@@ -82,7 +83,6 @@ function addMoreFunctionality(uniqueid){
                             <li><a href="#" uniqueid="${uniqueid}" effect="Show Image">Show Image</a></li>
                             ` + customScriptOptionHtml +
                             `
-                            <li><a href="#" uniqueid="${uniqueid}" effect="Delay">Delay</a></li>
                         </ul>
                     </div>
                     <div class="effect-settings-panel">
@@ -167,13 +167,15 @@ function functionalitySwitcher(uniqueid, effect){
 
 function delaySettings(uniqueid) {
   var effectTemplate = `
-      <div class="effect-specific-title"><h4>How long should the delay be?</h4></div>
-      <div class="input-group">
-          <span class="input-group-addon" id="delay-length-effect-type">Seconds</span>
-          <input type="text" class="form-control" id="delay-length-setting" aria-describedby="delay-length-effect-type" type="number">
+      <div class="effect-setting-container">
+        <div class="effect-specific-title"><h4>How long should the delay be?</h4></div>
+        <div class="input-group">
+            <span class="input-group-addon" id="delay-length-effect-type">Seconds</span>
+            <input type="text" class="form-control" id="delay-length-setting" aria-describedby="delay-length-effect-type" type="number">
+        </div>
       </div>
 
-      <div class="effect-info">
+      <div class="effect-info alert alert-info">
           Note: Delays dont wait for the previous effect to finish so take that into account, if required. For example, if your first effect plays a sound thats 10 seconds long and you want a 10 second delay after that sound, make the delay last 20 seconds.
       </div>
   `;
@@ -200,18 +202,20 @@ function customScriptSettings(uniqueid) {
   var jsFileList = getHtmlScriptFileList();
   
   var effectTemplate = `
-      <div class="effect-specific-title"><h4>Which script would you like to use?</h4></div>
-      <div class="effect-info">
-          Place scripts in the <a id="scriptFolderBtn" href="#" onclick="openScriptsFolder()">scripts folder</a> of the root Firebot directory, then refresh the dropdown.
+      <div class="effect-setting-container">
+        <div class="effect-specific-title"><h4>Which script would you like to use?</h4></div>
+        <div class="effect-info alert alert-info">
+            Place scripts in the <a id="scriptFolderBtn" href="#" onclick="openScriptsFolder()">scripts folder</a> of the root Firebot directory, then refresh the dropdown.
+        </div>
+        <div class="btn-group">
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="script-type">Pick One</span> <span class="caret"></span>
+        </button>
+        <a id="refreshScriptList" href="#" style="padding-left:5px;height:100%;"><i class="fa fa-refresh" id="refreshIcon" style="margin-top:10px;" aria-hidden="true"></i></a>
+        <ul class="dropdown-menu script-dropdown">${jsFileList}</ul>
+        </div>
       </div>
-      <div class="btn-group">
-      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <span class="script-type">Pick One</span> <span class="caret"></span>
-      </button>
-      <a id="refreshScriptList" href="#" style="padding-left:5px;height:100%;"><i class="fa fa-refresh" id="refreshIcon" style="margin-top:10px;" aria-hidden="true"></i></a>
-      <ul class="dropdown-menu script-dropdown">${jsFileList}</ul>
-      </div>
-      <div class="effect-info" style="color:red">
+      <div class="effect-info" alert alert-danger>
           <strong>Warning:</strong> Only use scripts from sources you absolutely trust!
       </div>
   `;
@@ -253,34 +257,38 @@ function customScriptSettings(uniqueid) {
 function apiButtonSettings(uniqueid){
 
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>Which API should I use?</h4></div>
-        <div class="btn-group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class="api-effect-type">Pick One</span> <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu api-effect-dropdown">
-            <li><a href="#">Advice</a></li>
-            <li><a href="#">Cat Picture</a></li>
-            <li><a href="#">Cat Fact</a></li>
-            <li><a href="#">Dog Picture</a></li>
-            <li><a href="#">Dog Fact</a></li>
-            <li><a href="#">Aww</a></li>
-            <li><a href="#">Pokemon</a></li>
-            <li><a href="#">Number Trivia</a></li>
-        </ul>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Which API should I use?</h4></div>
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="api-effect-type">Pick One</span> <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu api-effect-dropdown">
+                    <li><a href="#">Advice</a></li>
+                    <li><a href="#">Cat Picture</a></li>
+                    <li><a href="#">Cat Fact</a></li>
+                    <li><a href="#">Dog Picture</a></li>
+                    <li><a href="#">Dog Fact</a></li>
+                    <li><a href="#">Aww</a></li>
+                    <li><a href="#">Pokemon</a></li>
+                    <li><a href="#">Number Trivia</a></li>
+                </ul>
+            </div>
         </div>
-        <div class="effect-specific-title"><h4>Who should I send this as?</h4></div>
-        <div class="btn-group">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="api-chat-effect-type">Pick One</span> <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu api-chat-effect-dropdown">
-                <li><a href="#">Streamer</a></li>
-                <li><a href="#">Bot</a></li>
-            </ul>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Who should I send this as?</h4></div>
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="api-chat-effect-type">Pick One</span> <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu api-chat-effect-dropdown">
+                    <li><a href="#">Streamer</a></li>
+                    <li><a href="#">Bot</a></li>
+                </ul>
+            </div>
         </div>
-        <div class="effect-info">
-            Warning: These API's pull from a third party and I have no control over the quality or content.
+        <div class="effect-info alert alert-danger">
+            Warning: These API's pull from a third party and we have no control over the quality or content.
         </div>
     `;
 
@@ -304,17 +312,19 @@ function apiButtonSettings(uniqueid){
 // Loads up the settings for the change scene effect type.
 function changeGroupSettings(uniqueid){
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>Which group should I switch the person to?</h4></div>
-        <div class="btn-group">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="change-group-effect-type">Pick One</span> <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu change-group-effect-dropdown">
-                <li><a href="#" group="default">Default</a></li>
-            </ul>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Which group should I switch the person to?</h4></div>
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="change-group-effect-type">Pick One</span> <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu change-group-effect-dropdown">
+                    <li><a href="#" group="default">Default</a></li>
+                </ul>
+            </div>
         </div>
-        <div class="effect-info">
-            This button will move whoever clicks it to a new group (ex: From Default to "AwesomeGroup"). So, make sure you assign a scene to that group. If no groups are listed, that means you need to create a new custom group. I recommend a minimum one second cooldown on any buttons using this, otherwise you risk breaking the board.
+        <div class="effect-info alert alert-info">
+            This button will move whomever clicks it to a new group (ex: From Default to "AwesomeGroup"). So, make sure you assign a scene to that group. If no groups are listed, that means you need to create a new custom group. I recommend a minimum one second cooldown on any buttons using this, otherwise you risk breaking the board.
         </div>
     `;
 
@@ -368,42 +378,50 @@ function changeGroupSettings(uniqueid){
 // Loads up the settings for the change scene effect type.
 function changeSceneSettings(uniqueid){
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>Will we be resetting scenes to default or changing them?</h4></div>
-        <div class="btn-group">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="change-scene-type-effect-type">Pick One</span> <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu change-scene-type-effect-dropdown">
-                <li><a href="#">Change Scenes</a></li>
-                <li><a href="#">Reset Scenes</a></li>
-            </ul>
-        </div>
-        <div class="change-scene-wrap" style="display:none">
-            <div class="effect-specific-title"><h4>Which group(s) should change scenes?</h4></div>
-            <div class="change-scene-effect-group-select">
-                <div class="change-scene-effect-group-option custom-change-scene-group">
-                    <input type="checkbox" group="default" aria-label="..."> <span>Default</span>
-                </div>
-            </div>
-            <div class="effect-specific-title"><h4>Which scene should we change to?</h4></div>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Will we be resetting scenes to default or changing them?</h4></div>
             <div class="btn-group">
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    <span class="change-scene-to-effect-type">Pick One</span> <span class="caret"></span>
+                    <span class="change-scene-type-effect-type">Pick One</span> <span class="caret"></span>
                 </button>
-                <ul class="dropdown-menu change-scene-to-effect-dropdown"></ul>
+                <ul class="dropdown-menu change-scene-type-effect-dropdown">
+                    <li><a href="#">Change Scenes</a></li>
+                    <li><a href="#">Reset Scenes</a></li>
+                </ul>
             </div>
-            <div class="effect-info">
+        </div>
+        <div class="change-scene-wrap" style="display:none">
+            <div class="effect-setting-container">
+                <div class="effect-specific-title"><h4>Which group(s) should change scenes?</h4></div>
+                <div class="change-scene-effect-group-select">
+                    <div class="change-scene-effect-group-option custom-change-scene-group">
+                        <input type="checkbox" group="default" aria-label="..."> <span>Default</span>
+                    </div>
+                </div>
+            </div>
+            <div class="effect-setting-container">
+                <div class="effect-specific-title"><h4>Which scene should we change to?</h4></div>
+                <div class="btn-group">
+                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span class="change-scene-to-effect-type">Pick One</span> <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu change-scene-to-effect-dropdown"></ul>
+                </div>
+            </div>
+            <div class="effect-info alert alert-info">
                 This button will change the default scene for a group. This means that everyone in that group will get the buttons from whatever scene you select. I recommend a minimum one second cooldown on any buttons using this, otherwise you risk breaking the board.
             </div>
         </div>
         <div class="reset-scene-wrap" style="display:none">
-            <div class="effect-specific-title"><h4>Which group(s) should we reset?</h4></div>
-            <div class="reset-scene-effect-group-select">
-                <div class="change-scene-effect-group-option custom-change-scene-group">
-                    <input type="checkbox" group="default" aria-label="..."> <span>Default</span>
+            <div class="effect-setting-container">
+                <div class="effect-specific-title"><h4>Which group(s) should we reset?</h4></div>
+                <div class="reset-scene-effect-group-select">
+                    <div class="change-scene-effect-group-option custom-change-scene-group">
+                        <input type="checkbox" group="default" aria-label="..."> <span>Default</span>
+                    </div>
                 </div>
             </div>
-            <div class="effect-info">
+            <div class="effect-info alert alert-info">
                 This button will reset any groups you choose back to their default scene. This applies to everyone in the group. I recommend a minimum one second cooldown on any buttons using this, otherwise you risk breaking the board.
             </div>
         </div>
@@ -490,27 +508,33 @@ function changeSceneSettings(uniqueid){
 // Loads up settings for the chat effect type.
 function chatSettings(uniqueid){
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>Who should I chat as?</h4></div>
-        <div class="btn-group">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="chat-effect-type">Pick One</span> <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu chat-effect-dropdown">
-                <li><a href="#">Streamer</a></li>
-                <li><a href="#">Bot</a></li>
-            </ul>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Who should I chat as?</h4></div>
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="chat-effect-type">Pick One</span> <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu chat-effect-dropdown">
+                    <li><a href="#">Streamer</a></li>
+                    <li><a href="#">Bot</a></li>
+                </ul>
+            </div>
         </div>
-        <div class="effect-specific-title"><h4>What should I say?</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="chat-text-effect-type">Message</span>
-            <input type="text" class="form-control" id="chat-text-setting" aria-describedby="chat-text-effect-type" maxlength="360">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>What should I say?</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="chat-text-effect-type">Message</span>
+                <input type="text" class="form-control" id="chat-text-setting" aria-describedby="chat-text-effect-type" maxlength="360">
+            </div>
         </div>
-        <div class="effect-specific-title"><h4>Who should I whisper this to? Leave blank to broadcast to everyone.</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="chat-whisper-effect-type">Whisper</span>
-            <input type="text" class="form-control" id="chat-whisper-setting" aria-describedby="chat-text-effect-type">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Who should I whisper this to? Leave blank to broadcast to everyone.</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="chat-whisper-effect-type">Whisper</span>
+                <input type="text" class="form-control" id="chat-whisper-setting" aria-describedby="chat-text-effect-type">
+            </div>
         </div>
-        <div class="effect-info">
+        <div class="effect-info alert alert-info">
             The variable $(user) will be replaced by the username of the person who pressed the button. EX: If Firebottle hits a button you can whisper him.
         </div>
     `;
@@ -529,23 +553,21 @@ function chatSettings(uniqueid){
 // Loads up the settings for the cooldown effect type.
 function cooldownSettings(uniqueid){
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>Which buttons should I put on cooldown?</h4></div>
-        <div class="btn-group">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="cooldown-button-effect-type">Pick One</span> <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu cooldown-button-effect-dropdown">
-            </ul>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Which buttons should I put on cooldown?</h4></div>
+            <div class="cooldown-group-buttons"></div>
+            <div class="cooldown-group-button-reset">
+                <button class="btn btn-warning">Uncheck all</button>
+            </div>
         </div>
-        <div class="selected-cooldown-buttons">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>How long should these cooldown for?</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="cooldown-amount-effect-type">Seconds</span>
+                <input type="text" class="form-control" id="cooldown-amount-setting" aria-describedby="cooldown-amount-effect-type" type="number">
+            </div>
         </div>
-
-        <div class="effect-specific-title"><h4>How long should these cooldown for?</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="cooldown-amount-effect-type">Seconds</span>
-            <input type="text" class="form-control" id="cooldown-amount-setting" aria-describedby="cooldown-amount-effect-type" type="number">
-        </div>
-        <div class="effect-info">
+        <div class="effect-info alert alert-info">
             If you want to cool down a lot of buttons at the same time, give the cooldown groups a try in the board main settings!
         </div>
     `;
@@ -566,27 +588,20 @@ function cooldownSettings(uniqueid){
             var controls = scene.controls;
             for (button of controls){
                 var name = button.controlID;
-                var dropdowntemplate = `<li><a href="#">${name}</a></li>`;
-                $(".panel"+uniqueid+" .cooldown-button-effect-dropdown").append(dropdowntemplate);
+                var template = `
+                    <div class="cooldown-group-button-option">
+                        <input type="checkbox" button="${name}" aria-label="..."> <span>${name}</span>
+                    </div>
+                `;
+
+                $('.panel'+uniqueid+' .cooldown-group-buttons').append(template);
             }
         }
     } catch(err){};
 
-    // Add in a new button when one is selected.
-    $( ".cooldown-button-effect-dropdown a" ).click(function() {
-        var text = $(this).text();
-        var template = `<div class="selected-cooldown-button pill cooldown-`+uniqueid+`">
-                            <p class="content"><span>${text}</span></p>
-                            <div class="remove-cooldown pull-right">
-                                <button class="btn btn-danger">X</button>
-                            </div>
-                        </div>`;
-        $(".panel"+uniqueid+" .selected-cooldown-buttons").append(template);
-
-        // When X is clicked, remove button from list.
-        $(".panel"+uniqueid+" .remove-cooldown button").click(function(){
-            $(this).closest(".panel"+uniqueid+" .selected-cooldown-button").remove();
-        });
+    // Initialize uncheck button.
+    $('.panel'+uniqueid+' .cooldown-group-button-reset button').click(function(){
+        $('.panel'+uniqueid+' .cooldown-group-button-option input').prop('checked', false);
     });
 }
 
@@ -594,22 +609,25 @@ function cooldownSettings(uniqueid){
 // Loads up the settings for the celebration effect type.
 function celebrationSettings(uniqueid){
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>How should we celebrate?</h4></div>
-        <div class="btn-group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class="celebrate-effect-type">Pick One</span> <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu celebrate-effect-dropdown">
-            <li><a href="#">Fireworks</a></li>
-        </ul>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>How should we celebrate?</h4></div>
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="celebrate-effect-type">Pick One</span> <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu celebrate-effect-dropdown">
+                    <li><a href="#">Fireworks</a></li>
+                </ul>
+            </div>
         </div>
-
-        <div class="effect-specific-title"><h4>How many seconds should the party last?</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="celebration-length-effect-type">Seconds</span>
-            <input type="text" class="form-control" id="celebration-amount-setting" aria-describedby="celebration-length-effect-type" type="number">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>How many seconds should the party last?</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="celebration-length-effect-type">Seconds</span>
+                <input type="text" class="form-control" id="celebration-amount-setting" aria-describedby="celebration-length-effect-type" type="number">
+            </div>
         </div>
-        <div class="effect-info">
+        <div class="effect-info alert alert-info">
             This effect requires the overlay file to be loaded into your streaming software. Look in the Firebot folder for "/overlay/firebot.html".
         </div>
     `;
@@ -628,27 +646,33 @@ function celebrationSettings(uniqueid){
 // Loads up settings for the dice effect type.
 function diceSettings(uniqueid){
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>Who should I announce the roll as?</h4></div>
-        <div class="btn-group">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="dice-effect-type">Pick One</span> <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu dice-effect-dropdown">
-                <li><a href="#">Streamer</a></li>
-                <li><a href="#">Bot</a></li>
-            </ul>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Who should I announce the roll as?</h4></div>
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="dice-effect-type">Pick One</span> <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu dice-effect-dropdown">
+                    <li><a href="#">Streamer</a></li>
+                    <li><a href="#">Bot</a></li>
+                </ul>
+            </div>
         </div>
-        <div class="effect-specific-title"><h4>Who should I whisper this to? Leave blank to broadcast to everyone.</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="dice-whisper-effect-type">Whisper</span>
-            <input type="text" class="form-control" id="dice-whisper-setting" aria-describedby="dice-text-effect-type">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Who should I whisper this to? Leave blank to broadcast to everyone.</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="dice-whisper-effect-type">Whisper</span>
+                <input type="text" class="form-control" id="dice-whisper-setting" aria-describedby="dice-text-effect-type">
+            </div>
         </div>
-        <div class="effect-specific-title"><h4>What should I roll?</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="dice-text-effect-type">Dice</span>
-            <input type="text" class="form-control" id="dice-text-setting" aria-describedby="dice-text-effect-type" placeholder="2d20 or 2d10+1d12 or 1d10+3">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>What should I roll?</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="dice-text-effect-type">Dice</span>
+                <input type="text" class="form-control" id="dice-text-setting" aria-describedby="dice-text-effect-type" placeholder="2d20 or 2d10+1d12 or 1d10+3">
+            </div>
         </div>
-        <div class="effect-info">
+        <div class="effect-info alert alert-info">
             The variable $(user) will be replaced by the username of the person who pressed the button. EX: If Firebottle hits a button you can whisper him.
         </div>
     `;
@@ -667,39 +691,43 @@ function diceSettings(uniqueid){
 // Loads up the settings for the game control effect type.
 function gameControlSettings(uniqueid){
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>Which button should I press?</h4></div>
-        <div class="input-group game-press">
-            <span class="input-group-addon" id="button-press-effect-type">Press</span>
-            <input type="text" class="form-control" id="game-control-press-setting" aria-describedby="button-press-effect-type">
-        </div>
-
-        <div class="effect-specific-title"><h4>Should we press any modifiers also?</h4></div>
-        <div class="button-press-modifier-effect-type">
-            <div class="button-press-modifier-effect-inputs">
-                <input type="checkbox" key="control" aria-label="..."> <span>Control</span> <br>
-                <input type="checkbox" key="alt" aria-label="..."> <span>Alt</span> <br>
-                <input type="checkbox" key="shift" aria-label="..."> <span>Shift</span>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Which button should I press?</h4></div>
+            <div class="input-group game-press">
+                <span class="input-group-addon" id="button-press-effect-type">Press</span>
+                <input type="text" class="form-control" id="game-control-press-setting" aria-describedby="button-press-effect-type">
             </div>
         </div>
-
-        <div class="effect-specific-title"><h4>Does this button have an opposite button? (EX: Game Movement)</h4></div>
-        <div class="input-group game-opposite">
-            <span class="input-group-addon" id="opposite-button-effect-type">Opposite</span>
-            <input type="text" class="form-control" id="game-control-opposite-setting" aria-describedby="opposite-button-effect-type">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Should we press any modifiers also?</h4></div>
+            <div class="button-press-modifier-effect-type">
+                <div class="button-press-modifier-effect-inputs">
+                    <input type="checkbox" key="control" aria-label="..."> <span>Control</span> <br>
+                    <input type="checkbox" key="alt" aria-label="..."> <span>Alt</span> <br>
+                    <input type="checkbox" key="shift" aria-label="..."> <span>Shift</span>
+                </div>
+            </div>
         </div>
-
-        <div class="effect-specific-title"><h4>Is this a button that should be held down?</h4></div>
-        <div class="btn-group">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="holding-button-effect-type">No</span> <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu holding-button-effect-dropdown">
-                <li><a href="#">No</a></li>
-                <li><a href="#">Yes</a></li>
-            </ul>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Does this button have an opposite button? (EX: Game Movement)</h4></div>
+            <div class="input-group game-opposite">
+                <span class="input-group-addon" id="opposite-button-effect-type">Opposite</span>
+                <input type="text" class="form-control" id="game-control-opposite-setting" aria-describedby="opposite-button-effect-type">
+            </div>
         </div>
-
-        <div class="effect-info">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Is this a button that should be held down?</h4></div>
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="holding-button-effect-type">No</span> <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu holding-button-effect-dropdown">
+                    <li><a href="#">No</a></li>
+                    <li><a href="#">Yes</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="effect-info alert alert-info">
             Game controls do not work in every game or with every program. These are emulated controls. If the controls aren't working on your game or app try changing the emulator in the app settings.
         </div>
     `;
@@ -729,24 +757,27 @@ function gameControlSettings(uniqueid){
 // Loads up the settings for the show HTML effect type.
 function htmlSettings(uniqueid){
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>What HTML should we output?</h4></div>
-        <div class="input-group">
-            <textarea class="form-control" id="html-effect-html-field" name="text" placeholder="Input your HTML" rows="5" cols="40" width="100%"></textarea>
-        </div><!-- /input-group -->
-
-        <div class="effect-specific-title"><h4>How long should it show?</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="html-length-effect-type">Seconds</span>
-            <input type="text" class="form-control" id="html-length-setting" aria-describedby="html-length-effect-type" type="number">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>What HTML should we output?</h4></div>
+            <div class="input-group">
+                <textarea class="form-control" id="html-effect-html-field" name="text" placeholder="Input your HTML" rows="5" cols="40" width="100%"></textarea>
+            </div>
         </div>
-
-        <div class="effect-specific-title"><h4>What item should I remove after the show timer expires?</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="html-selector-effect-type">CSS Class</span>
-            <input type="text" class="form-control" id="html-selector-setting" aria-describedby="html-selector-effect-type">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>How long should it show?</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="html-length-effect-type">Seconds</span>
+                <input type="text" class="form-control" id="html-length-setting" aria-describedby="html-length-effect-type" type="number">
+            </div>
         </div>
-
-        <div class="effect-info">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>What item should I remove after the show timer expires?</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="html-selector-effect-type">CSS Class</span>
+                <input type="text" class="form-control" id="html-selector-setting" aria-describedby="html-selector-effect-type">
+            </div>
+        </div>
+        <div class="effect-info alert alert-info">
             This effect requires the overlay file to be loaded into your streaming software. Look in the Firebot folder for "/overlay/firebot.html". Also, please be aware that this button is EXTREMELY prone to error due to open ended nature.
         </div>
     `;
@@ -759,20 +790,23 @@ function htmlSettings(uniqueid){
 // Loads up the settings for the play sound effect type.
 function playSoundSettings(uniqueid){
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>What sound should I play?</h4></div>
-        <div class="input-group">
-            <span class="input-group-btn">
-            <button class="btn btn-default play-sound-effect-chooser" type="button">Choose</button>
-            </span>
-            <input type="text" class="form-control play-sound-effect-input">
-        </div><!-- /input-group -->
-
-        <div class="effect-specific-title"><h4>How loud should it be?</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="volume-effect-type">1-10</span>
-            <input type="text" class="form-control" id="sound-volume-setting" aria-describedby="volume-effect-type" type="number" min="1" max="10">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>What sound should I play?</h4></div>
+            <div class="input-group">
+                <span class="input-group-btn">
+                <button class="btn btn-default play-sound-effect-chooser" type="button">Choose</button>
+                </span>
+                <input type="text" class="form-control play-sound-effect-input">
+            </div>
         </div>
-        <div class="effect-info">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>How loud should it be?</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="volume-effect-type">1-10</span>
+                <input type="text" class="form-control" id="sound-volume-setting" aria-describedby="volume-effect-type" type="number" min="1" max="10">
+            </div>
+        </div>
+        <div class="effect-info alert alert-info">
             FYI, sounds are played through the Firebot app itself and not the overlay file.
         </div>
     `;
@@ -792,49 +826,54 @@ function playSoundSettings(uniqueid){
 // Loads up the settings for the show image effect type.
 function showImageSettings(uniqueid){
     var effectTemplate = `
-        <div class="effect-specific-title"><h4>Which image should I show?</h4></div>
-        <div class="input-group">
-            <span class="input-group-btn">
-            <button class="btn btn-default show-image-effect-chooser" type="button">Choose</button>
-            </span>
-            <input type="text" class="form-control show-image-effect-input">
-        </div><!-- /input-group -->
-
-        <div class="effect-specific-title"><h4>What location should it show in?</h4></div>
-        <div class="btn-group">
-            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="image-placement-effect-type">Pick One</span> <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu image-placement-effect-dropdown">
-                <li><a href="#">Top Left</a></li>
-                <li><a href="#">Top Middle</a></li>
-                <li><a href="#">Top Right</a></li>
-                <li><a href="#">Middle Left</a></li>
-                <li><a href="#">Middle</a></li>
-                <li><a href="#">Middle Right</a></li>
-                <li><a href="#">Bottom Left</a></li>
-                <li><a href="#">Bottom Middle</a></li>
-                <li><a href="#">Bottom Right</a></li>
-            </ul>
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>Which image should I show?</h4></div>
+            <div class="input-group">
+                <span class="input-group-btn">
+                <button class="btn btn-default show-image-effect-chooser" type="button">Choose</button>
+                </span>
+                <input type="text" class="form-control show-image-effect-input">
+            </div>
         </div>
-
-        <div class="effect-specific-title"><h4>How big should it be?</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="image-size-type">Height (in pixels)</span>
-            <input type="text" class="form-control" id="image-height-setting" aria-describeby="image-height-setting-type" type="number">
-            <span class="input-group-addon" id="image-size-type">Width (in pixels)</span>
-            <input type="text" class="form-control" id="image-width-setting" aria-describeby="image-width-setting-type" type="number">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>What location should it show in?</h4></div>
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="image-placement-effect-type">Pick One</span> <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu image-placement-effect-dropdown">
+                    <li><a href="#">Top Left</a></li>
+                    <li><a href="#">Top Middle</a></li>
+                    <li><a href="#">Top Right</a></li>
+                    <li><a href="#">Middle Left</a></li>
+                    <li><a href="#">Middle</a></li>
+                    <li><a href="#">Middle Right</a></li>
+                    <li><a href="#">Bottom Left</a></li>
+                    <li><a href="#">Bottom Middle</a></li>
+                    <li><a href="#">Bottom Right</a></li>
+                </ul>
+            </div>
         </div>
-        <div class="effect-info">
-            Just put numbers in the fields (ex: 250). This will set the max width/height of the image and scale it down proportionally.
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>How big should it be?</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="image-size-type">Height (in pixels)</span>
+                <input type="text" class="form-control" id="image-height-setting" aria-describeby="image-height-setting-type" type="number">
+                <span class="input-group-addon" id="image-size-type">Width (in pixels)</span>
+                <input type="text" class="form-control" id="image-width-setting" aria-describeby="image-width-setting-type" type="number">
+            </div>
+            <div class="effect-info alert alert-info">
+                Just put numbers in the fields (ex: 250). This will set the max width/height of the image and scale it down proportionally.
+            </div>
         </div>
-
-        <div class="effect-specific-title"><h4>How long should it show?</h4></div>
-        <div class="input-group">
-            <span class="input-group-addon" id="image-length-effect-type">Seconds</span>
-            <input type="text" class="form-control" id="image-length-setting" aria-describedby="image-length-effect-type" type="number">
+        <div class="effect-setting-container">
+            <div class="effect-specific-title"><h4>How long should it show?</h4></div>
+            <div class="input-group">
+                <span class="input-group-addon" id="image-length-effect-type">Seconds</span>
+                <input type="text" class="form-control" id="image-length-setting" aria-describedby="image-length-effect-type" type="number">
+            </div>
         </div>
-        <div class="effect-info">
+        <div class="effect-info alert alert-info">
             This effect requires the overlay file to be loaded into your streaming software. Look in the Firebot folder for "/overlay/firebot.html".
         </div>
     `;
@@ -1037,9 +1076,10 @@ function saveControls(){
         case "Cooldown":
             // Cycle through selected buttons and push to array.
             var cooldownButtons = [];
-            $( ".selected-cooldown-buttons" ).find('.selected-cooldown-button').each(function( index ) {
-                var text = $(this).find('span').text();
-                cooldownButtons.push(text);
+            // Loop through selected buttons and get control id.
+            $(this).find('.cooldown-group-button-option input:checked').each(function( index ) {
+                var button = $(this).attr('button');
+                cooldownButtons.push(button);
             });
             var cooldownLength = $(this).find('#cooldown-amount-setting').val();
             dbControls.push('./firebot/controls/'+controlID+'/effects/'+i, {"type": "Cooldown", "buttons": cooldownButtons, "length": cooldownLength});
@@ -1177,19 +1217,7 @@ function loadSettings(controlId, button){
                 // Cycle through selected buttons and push to array.
                 var cooldownButtons = effect.buttons;
                 for (button of cooldownButtons){
-                    var text = button;
-                    var template = `<div class="selected-cooldown-button pill cooldown-`+uniqueid+`">
-                                        <p class="content"><span>${text}</span></p>
-                                        <div class="remove-cooldown pull-right">
-                                            <button class="btn btn-danger">X</button>
-                                        </div>
-                                    </div>`;
-                    $(".panel"+uniqueid+" .selected-cooldown-buttons").append(template);
-
-                    // When X is clicked, remove button from list.
-                    $(".panel"+uniqueid+" .remove-cooldown button").click(function(){
-                        $(this).closest(".panel"+uniqueid+" .selected-cooldown-button").remove();
-                    });
+                    $('.panel'+uniqueid+' .cooldown-group-button-option input[button='+button+']').prop('checked', true);
                 }
                 $('.panel'+uniqueid+' #cooldown-amount-setting').val(effect.length);
                 break;

--- a/gui/js/interactive/interactive-board.js
+++ b/gui/js/interactive/interactive-board.js
@@ -507,7 +507,7 @@ function addCooldownGroup(){
     // Clear old settings.
     $(".cooldown-groupid").val('');
     $(".cooldown-group-length").val('');
-    $(".selected-cooldown-group-buttons").empty();
+    $('.cooldown-group-button-option').remove();
     $('.cooldown-group-dropdown').empty();
 
     // Pull in all buttons for selected board.
@@ -523,27 +523,20 @@ function addCooldownGroup(){
             var controls = scene.controls;
             for (button of controls){
                 var name = button.controlID;
-                var dropdowntemplate = `<li><a href="#">${name}</a></li>`;
-                $(".cooldown-group-dropdown").append(dropdowntemplate);
+                var template = `
+                    <div class="cooldown-group-button-option">
+                        <input type="checkbox" button="${name}" aria-label="..."> <span>${name}</span>
+                    </div>
+                `;
+
+                $(".cooldown-group-buttons").append(template);
             }
         }
     } catch(err){};
 
-    // Add in a new button when one is selected.
-    $( ".cooldown-group-dropdown a" ).click(function() {
-        var text = $(this).text();
-        var template = `<div class="selected-cooldown-group-button pill">
-                            <p class="content"><span>${text}</span></p>
-                            <div class="remove-cooldown-group-button pull-right">
-                                <button class="btn btn-danger">X</button>
-                            </div>
-                        </div>`;
-        $(".selected-cooldown-group-buttons").append(template);
-
-        // When X is clicked, remove button from list.
-        $(".remove-cooldown-group-button button").click(function(){
-            $(this).closest(".selected-cooldown-group-button").remove();
-        });
+    // Initialize uncheck button.
+    $(".cooldown-group-button-reset button").click(function(){
+        $('.cooldown-group-button-option input').prop('checked', false);
     });
 
     // Hide delete button;
@@ -561,29 +554,13 @@ function editCooldownGroup(sceneid){
     // Clear old settings.
     $(".cooldown-groupid").val('');
     $(".cooldown-group-length").val('');
-    $(".selected-cooldown-group-buttons").empty();
+    $('.cooldown-group-button-option').remove();
     $('.cooldown-group-dropdown').empty();
 
     // Load easy info
     $('#newCooldownGroupLabel').text('Edit Cooldown Group');
     $('.cooldown-groupid').val(sceneid);
     $('.cooldown-group-length').val(length);
-
-    // Loop through buttons and add them in.
-    for (button of buttons){
-        var template = `<div class="selected-cooldown-group-button pill">
-                            <p class="content"><span>${button}</span></p>
-                            <div class="remove-cooldown-group-button pull-right">
-                                <button class="btn btn-danger">X</button>
-                            </div>
-                        </div>`;
-        $(".selected-cooldown-group-buttons").append(template);
-
-        // Intialize delete button.
-        $(".remove-cooldown-group-button button").click(function(){
-            $(this).closest(".selected-cooldown-group-button").remove();
-        });
-    }
 
     // Pull in all buttons for selected board.
     try{
@@ -598,28 +575,21 @@ function editCooldownGroup(sceneid){
             var controls = scene.controls;
             for (button of controls){
                 var name = button.controlID;
-                var dropdowntemplate = `<li><a href="#">${name}</a></li>`;
-                $(".cooldown-group-dropdown").append(dropdowntemplate);
+                var template = `
+                    <div class="cooldown-group-button-option">
+                        <input type="checkbox" button="${name}" aria-label="..."> <span>${name}</span>
+                    </div>
+                `;
+
+                $(".cooldown-group-buttons").append(template);
             }
         }
     } catch(err){};
 
-    // Add in a new button when one is selected.
-    $( ".cooldown-group-dropdown a" ).click(function() {
-        var text = $(this).text();
-        var template = `<div class="selected-cooldown-group-button pill">
-                            <p class="content"><span>${text}</span></p>
-                            <div class="remove-cooldown-group-button pull-right">
-                                <button class="btn btn-danger">X</button>
-                            </div>
-                        </div>`;
-        $(".selected-cooldown-group-buttons").append(template);
-
-        // When X is clicked, remove button from list.
-        $(".remove-cooldown-group-button button").click(function(){
-            $(this).closest(".selected-cooldown-group-button").remove();
-        });
-    });
+    // Loop through our saved buttons and check any that are saved.
+    for (button of buttons){
+        $('.cooldown-group-button-option input[button='+button+']').prop('checked', true);
+    }
 
     // We're editing, so show the delete button.
     $('.remove-cooldown-group').show();
@@ -632,6 +602,11 @@ function editCooldownGroup(sceneid){
         }catch(err){
             errorLog("Error deleting this cooldown group.")
         }
+    });
+
+    // Initialize uncheck button.
+    $(".cooldown-group-button-reset button").click(function(){
+        $('.cooldown-group-button-option input').prop('checked', false);
     });
 
     // Show Modal
@@ -649,12 +624,12 @@ function saveCooldownGroup(){
     var cooldownLength = $('.cooldown-group-length').val();
 
     // Loop through selected buttons and get control id.
-    $( ".selected-cooldown-group-buttons" ).find('.selected-cooldown-group-button').each(function( index ) {
-        var text = $(this).find('span').text();
-        cooldownButtons.push(text);
+    $( ".cooldown-group-button-option input:checked" ).each(function( index ) {
+        var button = $(this).attr('button');
+        cooldownButtons.push(button);
 
         // Push group info to db for each control.
-        dbControls.push('./firebot/controls/'+text+'/cooldownGroup', groupID);
+        dbControls.push('./firebot/controls/'+button+'/cooldownGroup', groupID);
     });
 
     // Push cooldown group info to db.

--- a/gui/scss/_interactive.scss
+++ b/gui/scss/_interactive.scss
@@ -21,8 +21,11 @@
         border-top: 1px solid $light-highlight;
         margin-top: 1em;
     }
+    .effect-setting-container{
+        padding:.5em 0em;
+    }
     .effect-info{
-        padding: .5em 0em;
+        margin:1em 0em;
     }
 }
 
@@ -89,4 +92,25 @@
 .board-group-defaults-settings, .board-cooldown-groups, .interactive-button-holder.active{
     display:flex;
     flex-wrap: wrap;
+}
+
+.cooldown-group-buttons{
+    height: 200px;
+    overflow:hidden;
+    overflow-y: scroll;
+    border: 1px solid #ccc;
+    border-radius:4px;
+    padding:6px 12px;
+    margin: 10px 0px;
+
+    .cooldown-group-button-option{
+        border-bottom:1px solid #cecece;
+        padding: 6px 0px;
+
+        input{
+            transform: scale(2);
+            margin:6px;
+        }
+    }
+
 }


### PR DESCRIPTION
Addresses #179 

I replaced all instances of the button dropdowns. These were located in the cooldown groups area and the cooldown button effect. It's now a scrollable list of all buttons that you can just check or uncheck.

I also added a container to each individual setting for all effects so that we can space those out more and make them a bit easier to distinguish. If we need to give them background colors or something later it'll be much easier now.

For all of the effect-info divs I added bootstrap alert styling. Regular info is in a blue box now and warnings are in red boxes. Should draw more attention now.