### PR TITLE
Fix for possible shortcut issue.

### DIFF
--- a/gui/js/login.js
+++ b/gui/js/login.js
@@ -200,7 +200,7 @@ ipcRenderer.on('getRefreshToken', function (event, data) {
     var status = $('.connection-text').text();
 
     // Send event to render process.
-    if (status === "Connected.") {
+    if (status.substring(0,9) === "Connected") {
         // Disconnect!
         ipcRenderer.send('mixerInteractive', 'disconnect');
     } else {


### PR DESCRIPTION
Fix for possible issue when using the shortcut CTRL+ALT+F12, the string it compares against is "Connected - Click to Disconnect", not "Connected." so it will never be seen as connected and never do anything else than to reconnect on triggering the shortcut. This cuts of the remaining characters after the ninth character so that it's seen as "Connected" instead of the whole string from the button.