### PR TITLE
"Change Scene" Effect Tweaks

### DIFF
--- a/gui/app/services/effectHelperService.js
+++ b/gui/app/services/effectHelperService.js
@@ -154,7 +154,6 @@
 
               // Set new scope var.
               $scope.effect.groups = groupArray;
-              console.log(groupArray)
             }
 
             // This uses the board service to get a list of scenes for the current board.
@@ -165,7 +164,11 @@
             // This checks if an item is in the effect.group array and returns true.
             // This allows us to check boxes when loading up this button effect.
             $scope.groupCheckboxer = function (group){
-              return $scope.effect.groups.indexOf(group) != -1;
+              if($scope.effect.groups != null) {
+                return $scope.effect.groups.indexOf(group) != -1;
+              } else {
+                return false;
+              }              
             }
 
           };

--- a/gui/app/templates/interactive/effect-options/change-scene.html
+++ b/gui/app/templates/interactive/effect-options/change-scene.html
@@ -15,9 +15,9 @@
     </div>
 </div>
 
-<div class="change-scene-wrap" ng-if="effect.reset === false">
+<div class="change-scene-wrap" ng-if="effect.reset != null">
     <div class="effect-setting-container">
-        <div class="effect-specific-title"><h4>Which group(s) should change scenes?</h4></div>
+        <div class="effect-specific-title"><h4>{{effect.reset ? 'Which group(s) should we reset?' : 'Which group(s) should change scenes?'}}</h4></div>
         <div class="change-scene-effect-group-select">
             <ul class="change-scene-effect-group-option custom-change-scene-group">
                 <li>
@@ -31,7 +31,7 @@
             </ul>
         </div>
     </div>
-    <div class="effect-setting-container">
+    <div class="effect-setting-container" ng-if="effect.reset === false">
         <div class="effect-specific-title"><h4>Which scene should we change to?</h4></div>
         <div class="btn-group">
             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -44,28 +44,10 @@
             </ul>
         </div>
     </div>
-    <div class="effect-info alert alert-info">
+    <div class="effect-info alert alert-info" ng-hide="effect.reset">
         This button will change the default scene for a group. This means that everyone in that group will get the buttons from whatever scene you select. I recommend a minimum one second cooldown on any buttons using this, otherwise you risk breaking the board.
     </div>
-</div>
-
-<div class="reset-scene-wrap" ng-if="effect.reset">
-    <div class="effect-setting-container">
-        <div class="effect-specific-title"><h4>Which group(s) should we reset?</h4></div>
-        <div class="reset-scene-effect-group-select">
-            <ul class="change-scene-effect-group-option custom-change-scene-group">
-                <li>
-                    <input type="checkbox" ng-click="groupArray('Default')" ng-checked="groupCheckboxer('Default')" aria-label="..." >
-                    <span>Default</span>
-                </li>
-                <li ng-repeat="group in viewerGroups">
-                    <input type="checkbox" ng-click="groupArray(group)" ng-checked="groupCheckboxer(group)" aria-label="..." >
-                    <span>{{group}}</span>
-                </li>
-            </ul>
-        </div>
-    </div>
-    <div class="effect-info alert alert-info">
+    <div class="effect-info alert alert-info" ng-show="effect.reset">
         This button will reset any groups you choose back to their default scene. This applies to everyone in the group. I recommend a minimum one second cooldown on any buttons using this, otherwise you risk breaking the board.
     </div>
 </div>


### PR DESCRIPTION
I missed a couple things in the last pull request. Sorry about that.

For some reason I didn't see the html file in the PR so I didn't review it till after the merge. But made a suggested change here that will allow us to reuse the group select checkboxes section, instead of having it in two places. 

I also use ng-show and ng-hide for the info textbox to showcase an alternative to ng-if. 
ng-show/ng-hide and ng-if both have their uses and it kinda depends on the situation for which is better. 
ng-if completely removes and adds the html element from the DOM (so its a little more expensive on large elements) and ng-show/hide just adds the "display: none;" css property to an element (so its faster, but sometimes you might not want the element lurking around hidden).

I also gave bad advice on the groupCheckboxer function. We want to do a null/undefined check before doing an indexOf. While it didn't effect the behavior of the app, was causing a fair amount of console errors for a blank 'change scene' effect.