### PR TITLE
Putting knownBoards into settings.json to lower amount of file operations.

### DIFF
--- a/gui/app/services/boardService.js
+++ b/gui/app/services/boardService.js
@@ -84,19 +84,8 @@
       });
     };
     
-    // reload boards into memory
+        // reload boards into memory
     service.loadAllBoards = function() {
-      
-      // Attempt to access board flatfile storage
-      var boardJsonFiles = [];
-      try{
-          boardJsonFiles = fs.readdirSync('./user-settings/controls');          
-      }catch(err){
-        console.log(err);
-        return new Promise(function(resolve, reject) {
-          reject('No boards saved.')
-        });;
-      }
       
       /* Step 1 */  
       // Get a list or board ids so we can resync them all with Mixer
@@ -104,13 +93,55 @@
       // Note(ebiggz): Unfortunately this currently means we have to iterate through the files
       // to get the ids and iterate through the files a second time after we have synced with mixer.
       // There's surely a better way to do this. Maybe maintain a list of known board id's in the settings file?
-      var boardVersionIds = [];
-      _.each(boardJsonFiles, function (fileName) {
-        var boardDb = new JsonDB("./user-settings/controls/"+fileName, true, true);
-        var boardData = boardDb.getData('/');
-        
-        boardVersionIds.push(boardData.versionid);
-      });
+      try{
+        knownBoards = settingsService.getKnownBoards();
+        var boardVersionIds = [];
+        _.each(knownBoards, function(board){
+            boardVersionIds.push(board.boardId);
+        });
+        try{
+            if(typeof boardVersionIds != "undefined" && boardVersionIds != null && boardVersionIds.length > 0){
+                // console.log("We have data, no need to rebuild, proceed");
+            }else{
+                // console.log("This happened, we need to check for board files to see if we can rebuild them to get data in knownboards");
+                throw new Error('boardlist is empty, might be first run of new 4.0 version? Trying to salvage data from board jsons instead...');
+            }
+        }catch(err){
+            console.log("boardId is not present... We might have to reinitialize the board list...");
+            // Attempt to access board flatfile storage
+            var boardJsonFiles = [];
+            try{
+                boardJsonFiles = fs.readdirSync('./user-settings/controls');          
+            }catch(err){
+                console.log(err);
+                return new Promise(function(resolve, reject) {
+                reject('No boards saved.')
+                });;
+            }
+            
+            /* Step 1 */  
+            // Get a list or board ids so we can resync them all with Mixer
+            
+            // Note(ebiggz): Unfortunately this currently means we have to iterate through the files
+            // to get the ids and iterate through the files a second time after we have synced with mixer.
+            // There's surely a better way to do this. Maybe maintain a list of known board id's in the settings file?
+            var boardVersionIds = [];
+            _.each(boardJsonFiles, function (fileName) {
+                var boardDb = new JsonDB("./user-settings/controls/"+fileName, true, true);
+                var boardData = boardDb.getData('/');
+                
+                boardVersionIds.push(boardData.versionid);
+            });
+            
+            /* Step 2 */
+            // Load each board.
+            return loadBoardsById(boardVersionIds, true).then(() => { selectedBoard = service.getLastUsedBoard() });
+        }
+      }catch(err){
+          // We don't have any board data... Do something about it?
+          console.log("We don't have any board data... Panic? Riot? Riot?? Ok, blame Firebottle, it will be all good according to Waterbottle");
+          knownBoards = [];
+      }
       
       /* Step 2 */
       // Load each board.
@@ -344,7 +375,7 @@
                         // it back in without altering custom actions then we can swap this for a whole push instead
                         // of a singular one (Perry - 2017-06-28)
                         */
-                        
+
                         dbControls.push('./firebot/controls/'+controlID+'/controlId', controlID);
                         dbControls.push('./firebot/controls/'+controlID+'/scene', scenename);
                         dbControls.push('./firebot/controls/'+controlID+'/text', text);

--- a/gui/app/services/boardService.js
+++ b/gui/app/services/boardService.js
@@ -84,7 +84,7 @@
       });
     };
     
-        // reload boards into memory
+    // reload boards into memory
     service.loadAllBoards = function() {
       
       /* Step 1 */  
@@ -375,7 +375,7 @@
                         // it back in without altering custom actions then we can swap this for a whole push instead
                         // of a singular one (Perry - 2017-06-28)
                         */
-
+                        
                         dbControls.push('./firebot/controls/'+controlID+'/controlId', controlID);
                         dbControls.push('./firebot/controls/'+controlID+'/scene', scenename);
                         dbControls.push('./firebot/controls/'+controlID+'/text', text);

--- a/gui/app/services/settingsService.js
+++ b/gui/app/services/settingsService.js
@@ -38,7 +38,7 @@
     }
     
     service.getKnownBoards = function() {
-      // This should feed the boardService with known boards and their lastUpdated values. Not implemented yet.
+      // This feeds the boardService with known boards and their lastUpdated values.
       var boards = getDataFromFile('/boards');
       return boards;
     }


### PR DESCRIPTION
Moved the operations of getting boardIds into settings.json to lower amount of file operations during startup and in combinations with updatechecker this will really reduce the amounts of file writing operations during startup so it loads a lot quicker when you have huge boards loaded into the bot.
It might take a bit of loading when going from v3 to v4 since it has to read through the board files to get all the IDs and put them into settings.json. On future launches it will not read these files on load as it has the IDs in the right place. The same goes for from v4 pre knownBoards and the updated checker.