### PR TITLE
Button effects group fix

### DIFF
--- a/gui/app/services/effectHelperService.js
+++ b/gui/app/services/effectHelperService.js
@@ -123,16 +123,8 @@
         case EffectType.CHANGE_GROUP:
           controller = ($scope, groupsService) => {
 
-            // Load up viewer groups if they haven't been already.
-            // Leaving this out causes no groups to load unless you first visit the groups panel.
-            groupsService.loadViewerGroups();
-
             // Get viewer groups and push group name to scope.
-            $scope.viewerGroups = [];
-            var groups = groupsService.getViewerGroups();
-            for (group of groups){
-              $scope.viewerGroups.push(group.groupName);
-            }
+            $scope.viewerGroups = groupsService.getActiveGroups();
 
           };
           break;
@@ -152,17 +144,9 @@
               }
             }
 
-            // Load up viewer groups if they haven't been already.
-            // Leaving this out causes no groups to load unless you first visit the groups panel.
-            groupsService.loadViewerGroups();
-
             // Get viewer groups and push group name to scope.
             // This is for loading up all user group checkboxes.
-            $scope.viewerGroups = [];
-            var groups = groupsService.getViewerGroups();
-            for (group of groups){
-              $scope.viewerGroups.push(group.groupName);
-            }
+            $scope.viewerGroups = groupsService.getActiveGroups();
 
             // This is run each time a group checkbox is clicked or unclicked.
             // This will build an array of currently selected groups to be saved to JSON.

--- a/gui/app/services/groupsService.js
+++ b/gui/app/services/groupsService.js
@@ -39,9 +39,6 @@
     }
 
     service.getActiveGroups = function(){
-      // Load custom groups up incase they havent been already.
-      service.loadViewerGroups();
-
       // Get the selected board and set default groupList var.
       var dbGroup = boardService.getSelectedBoard();
       var groupList = [];

--- a/gui/app/services/groupsService.js
+++ b/gui/app/services/groupsService.js
@@ -37,6 +37,31 @@
       }
       return groupList;
     }
+
+    service.getActiveGroups = function(){
+      // Load custom groups up incase they havent been already.
+      service.loadViewerGroups();
+
+      // Get the selected board and set default groupList var.
+      var dbGroup = boardService.getSelectedBoard();
+      var groupList = [];
+
+      // Go through each scene on the current board and push default groups to groupList.
+      for (scene in dbGroup.scenes){
+        var scene = dbGroup.scenes[scene];
+        var sceneGroups = scene.default;
+        for(item of sceneGroups){
+          groupList.push(item);
+        }
+      }
+
+      // Filter out duplicates
+      groupList = groupList.filter(function(elem, pos) {
+          return groupList.indexOf(elem) == pos;
+      })
+
+      return groupList;
+    }
     
     service.addOrUpdateViewerGroup = function(group) {
       if(group.groupName == "banned") return;


### PR DESCRIPTION
This will make it so that change groups and change scenes button effects will only show active groups on the current board for selection.

There is a new function in the groupsService called "getActiveGroups" which returns an array of active groups for the current board.

To Test:
What happens if you set up a change scene button and then deactivate one of the groups you had selected for that button.