### PR TITLE
Include an arbitrary secret in auth request

### DIFF
--- a/gui/app/services/connectionService.js
+++ b/gui/app/services/connectionService.js
@@ -19,6 +19,7 @@
     
     var authInfo = {
         clientId: process.env.CLIENT_ID,
+        clientSecret: "firebot",
         authorizationUrl: "https://mixer.com/oauth/authorize",
         tokenUrl: "https://mixer.com/api/v1/oauth/token",
         useBasicAuthorizationHeader: false,
@@ -95,7 +96,12 @@
       const oauthProvider = electronOauth2(authInfo, authWindowParams);
       $q.when(oauthProvider.getAccessToken({ scope: scopes }))
           .then(token => {
+            if(token.name != null && token.name === "ValidationError") {               
+              utilityService.showErrorModal("There was an issue logging into Mixer. Error: " + token.details[0].message);
+              console.log(token);
+            } else {
               userInfo(type, token.access_token, token.refresh_token);
+            }   
           }, err => {
               //error requesting access 
               $rootScope.showSpinner = false;

--- a/gui/app/services/utilityService.js
+++ b/gui/app/services/utilityService.js
@@ -7,7 +7,7 @@
 
  angular
   .module('firebotApp')
-  .factory('utilityService', function ($uibModal, listenerService) {
+  .factory('utilityService', function ($rootScope, $uibModal, listenerService) {
     var service = {};
       
     service.showModal = function(showModalContext) {
@@ -68,28 +68,29 @@
     };
     
     service.showErrorModal = function (errorMessage) {
-        var errorModalContext = {
-          templateUrl: "errorModal.html",
-          // This is the controller to be used for the modal. 
-          controllerFunc: ($scope, $uibModalInstance, message) => {
-            
-            $scope.message = message;
-            
-            $scope.close = function() {
-              $uibModalInstance.close();
-            };
-            
-            $scope.dismiss = function() {
-              $uibModalInstance.dismiss('cancel');
-            };
-          },
-          resolveObj: {
-            message: () => {
-              return errorMessage;
-            }
+      $rootScope.showSpinner = false;
+      var errorModalContext = {
+        templateUrl: "errorModal.html",
+        // This is the controller to be used for the modal. 
+        controllerFunc: ($scope, $uibModalInstance, message) => {
+          
+          $scope.message = message;
+          
+          $scope.close = function() {
+            $uibModalInstance.close();
+          };
+          
+          $scope.dismiss = function() {
+            $uibModalInstance.dismiss('cancel');
+          };
+        },
+        resolveObj: {
+          message: () => {
+            return errorMessage;
           }
-        }      
-        service.showModal(errorModalContext);
+        }
+      }      
+      service.showModal(errorModalContext);
     }
     
     // This is used by effects that make use of lists of checkboxes. Returns and array of selected boxes.


### PR DESCRIPTION
This is a hotfix that would allow logins to work in 4.0 again. 

 Currently it seems Mixer is requiring a client secret even when our auth client isn't set up to use one.

This change includes an arbitrary string ("firebot") as the client secret for auth requests.

If this ends up being a temporary issue with Mixer, we can delete this PR. 