### PR TITLE
Cache layer for Settings

### DIFF
--- a/gui/app/services/settingsService.js
+++ b/gui/app/services/settingsService.js
@@ -11,6 +11,8 @@
   .factory('settingsService', function () {
     var service = {};
     
+    var settingsCache = {}
+    
     function getSettingsFile() {
       return new JsonDB("./user-settings/settings", true, true);
     }
@@ -18,19 +20,23 @@
     function pushDataToFile(path, data) {
       try {
           getSettingsFile().push(path, data);
+          settingsCache[path] = data;
       } catch(err){};
     }
     
-    function getDataFromFile(path) {
-      var data = null;
+    function getDataFromFile(path, forceCacheUpdate) {
       try{
-          data = getSettingsFile().getData(path);
+        if(settingsCache[path] == null || forceCacheUpdate) {
+          var data = getSettingsFile().getData(path);
+          settingsCache[path] = data;
+        }          
       } catch(err){};
-      return data
+      return settingsCache[path];
     }
     
     function deleteDataAtPath(path) {
       getSettingsFile().delete(path);
+      delete settingsCache[path];
     }
     
     service.getLastBoardName = function() {
@@ -109,6 +115,15 @@
     
     service.setOverlayCompatibility = function(overlay) {
       pushDataToFile('/settings/overlayImages', overlay);
+    }
+
+    service.getTheme = function() {
+      var theme = getDataFromFile('/settings/theme');
+      return theme != null ? theme : "Light";
+    }
+    
+    service.setTheme = function(theme) {
+      pushDataToFile('/settings/theme', theme);
     }
     
     service.soundsEnabled = function() {

--- a/gui/app/services/settingsService.js
+++ b/gui/app/services/settingsService.js
@@ -116,15 +116,6 @@
     service.setOverlayCompatibility = function(overlay) {
       pushDataToFile('/settings/overlayImages', overlay);
     }
-
-    service.getTheme = function() {
-      var theme = getDataFromFile('/settings/theme');
-      return theme != null ? theme : "Light";
-    }
-    
-    service.setTheme = function(theme) {
-      pushDataToFile('/settings/theme', theme);
-    }
     
     service.soundsEnabled = function() {
       var sounds = getDataFromFile('/settings/sounds');


### PR DESCRIPTION
This adds a simple caching layer into the settingsService. 

This means that we wont have to go to the json file every single time we need a setting, which can happen a lot with $scope updates for each setting we may be watching. If you are curious how often that is, throw a console.log in the `getDataFromFile` function in settingsService and watch the console light up when you start switching tabs and doing things.  So ultimately, this should help make sure performance stays nice and smooth. 

The cache elements shouldn't ever get stale as long as we always update and retrieve settings via the settingsService.

I also added an optional argument to the `getDataFromFile` function to allow us to force the cache to be updated (aka it gets the setting from the file) should we ever need it.