### PR TITLE
Removing ratelimit code from auto grouper. Adding in sanity check for…

### DIFF
--- a/lib/interactive/auto-grouper.js
+++ b/lib/interactive/auto-grouper.js
@@ -45,14 +45,21 @@ function chatAPIChecker(groupList){
         var currentTime = d.getTime();
 
         // See if we have any API calls left.
-        if (chatApiPool > 5 || currentTime > chatApiReset){
-            // We Do! So send a user on to get grouped and then remove them from the line.
-            var user = groupWaitList[0];
-            autoGroup(groupList, user.username, user.userid, user.participant);
-        } else {
-            // We have no API calls left.
-            console.log('We have hit our ratelimit! Skipping this call.');
-        }
+        var user = groupWaitList[0];
+        autoGroup(groupList, user.username, user.userid, user.participant);
+
+        // Commenting this code out for now 9-14-17 as the rate limit info on this chat call is no longer available on mixer.
+        // It looks like its either been removed or is no longer nessessary.
+        /* 
+            if (chatApiPool > 5 || currentTime > chatApiReset){
+                // We Do! So send a user on to get grouped and then remove them from the line.
+                var user = groupWaitList[0];
+                autoGroup(groupList, user.username, user.userid, user.participant);
+            } else {
+                // We have no API calls left.
+                console.log('We have hit our ratelimit! Skipping this call.');
+            }
+        */
     } else {
         // No users left in the queue.
         return;
@@ -172,11 +179,13 @@ function autoGroup(groupList, username, userid, participant){
         if(isUserGrouped === false){
             Chat.getUser(userid, function(response){
                 // Got a response!
+                //console.log(response);
 
                 // Get info on ratelimits.
                 var info = response.caseless.dict;
                 chatApiPool = info['x-ratelimit-remaining'];
                 chatApiReset = info['x-ratelimit-reset'];
+                console.log('Rate Limit: '+chatApiPool+' || '+chatApiReset);
 
                 // Get user roles
                 var response = response.body;

--- a/lib/interactive/control-router.js
+++ b/lib/interactive/control-router.js
@@ -50,6 +50,12 @@ function controlRouter(mouseevent, mixerControls, mixerControl, gameJson, inputE
             // Throw this button info into UI log.
             renderWindow.webContents.send('eventlog', {username: participant.username, event: "pressed the "+controlID+" button."});
         })
+        .catch((err) => {
+            console.log('Button is still on cooldown. Ignoring button press.');
+
+            // Throw this button info into UI log.
+            renderWindow.webContents.send('eventlog', {username: participant.username, event: "tried to press "+controlID+" but it is on cooldown."});
+        })
 
     } else {
         // Mouse up event called. 

--- a/lib/interactive/cooldowns.js
+++ b/lib/interactive/cooldowns.js
@@ -8,31 +8,51 @@ cooldownSaved = []
 function cooldownRouter(mixerControls, mixerControl, firebot, control){
 
     return new Promise((resolve, reject) => {
-        var cooldown = control.cooldown;
-        var groupName = control.cooldownGroup;
 
-        if(groupName !== undefined && groupName !== ""){
-            // This button has a cooldown group... so it's time to cool them all down.
-            var groupsJson = firebot.cooldownGroups[groupName];
+        var expired = cooldownExpireChecker(control.controlId);
 
-            try{
-                // This will error out if the cooldown group this button is assigned to no longer exists.
-                var buttons = groupsJson.buttons;
-                var cooldown = parseInt( groupsJson['length'] ) * 1000;
+        // Alright, this button is no longer on cooldown and ready to be pressed.
+        if(expired === true){
+            var cooldown = control.cooldown;
+            var groupName = control.cooldownGroup;
+    
+            if(groupName !== undefined && groupName !== ""){
+                // This button has a cooldown group... so it's time to cool them all down.
+                var groupsJson = firebot.cooldownGroups[groupName];
+    
+                try{
+                    // This will error out if the cooldown group this button is assigned to no longer exists.
+                    var buttons = groupsJson.buttons;
+                    var cooldown = parseInt( groupsJson['length'] ) * 1000;
+    
+                    // For each button in the cooldown group...
+                    groupCooldown(buttons, cooldown, firebot)
 
-                // For each button in the cooldown group...
-                groupCooldown(buttons, cooldown, firebot)
-
-                // Resolve
-                resolve(true);
-            }catch(err){
-                // This cooldown group was deleted. Fix this control.
-                var dbSettings = dataAccess.getJsonDbInUserData("/user-settings/settings");
-                var gameName = dbSettings.getData('/interactive/lastBoard');
-                var dbControls = dataAccess.getJsonDbInUserData("/user-settings/controls/"+gameName);
-                dbControls.delete('./firebot/controls/'+control.controlId+'/cooldownGroup');
-
-                // Let's check to see if this one button needs to cool down then...
+                }catch(err){
+                    // This cooldown group was deleted. Fix this control.
+                    var dbSettings = dataAccess.getJsonDbInUserData("/user-settings/settings");
+                    var gameName = dbSettings.getData('/interactive/lastBoard');
+                    var dbControls = dataAccess.getJsonDbInUserData("/user-settings/controls/"+gameName);
+                    dbControls.delete('./firebot/controls/'+control.controlId+'/cooldownGroup');
+    
+                    // Let's check to see if this one button needs to cool down then...
+                    if (cooldown !== undefined && cooldown > 0){
+                        var cooldown = parseInt(control.cooldown) * 1000;
+                        var cooldownCheck = cooldownChecker(control.controlId, cooldown);
+                        if(cooldownCheck === true){
+                            console.log('Cooling Down (Single): '+ control.controlId + ' for '+cooldown);
+                            mixerControl.setCooldown(cooldown);
+                        }
+                    }
+    
+                    // Button cooldown process complete.
+                    resolve(true);
+                }
+                
+            } else {
+                // Button doesn't have a cooldown group, so let's just cool down this one button.
+    
+                // If cooldown is not listed or zero, then don't do anything.
                 if (cooldown !== undefined && cooldown > 0){
                     var cooldown = parseInt(control.cooldown) * 1000;
                     var cooldownCheck = cooldownChecker(control.controlId, cooldown);
@@ -41,26 +61,14 @@ function cooldownRouter(mixerControls, mixerControl, firebot, control){
                         mixerControl.setCooldown(cooldown);
                     }
                 }
-
-                // Resolve
+    
+                // Button cooldown process complete.
                 resolve(true);
             }
-            
         } else {
-            // Button doesn't have a cooldown group, so let's just cool down this one button.
-
-            // If cooldown is not listed or zero, then don't do anything.
-            if (cooldown !== undefined && cooldown > 0){
-                var cooldown = parseInt(control.cooldown) * 1000;
-                var cooldownCheck = cooldownChecker(control.controlId, cooldown);
-                if(cooldownCheck === true){
-                    console.log('Cooling Down (Single): '+ control.controlId + ' for '+cooldown);
-                    mixerControl.setCooldown(cooldown);
-                }
-            }
-
-            // Resolve
-            resolve(true);
+            // This button is still on cooldown! Don't press it again.
+            console.log('Button '+control.controlID+' is still on cooldown. Ignoring press.');
+            reject(false);
         }
     });
 }
@@ -86,7 +94,7 @@ function groupCooldown(buttons, cooldown, firebot){
 
 // Cooldown Checker
 // This function checks to see if a button should be cooled down or not based on current cooldown count. 
-// It will return true if the new cooldown is longer than what is was already.
+// It will return true if the new cooldown is longer than what it was already.
 function cooldownChecker(buttonID, cooldown){
     // Get current time in milliseconds
     var dateNow = Date.now();
@@ -101,6 +109,25 @@ function cooldownChecker(buttonID, cooldown){
     if(oldTime === undefined || newTime > oldTime){
         // Push new value and resolve.
         cooldownSaved[buttonID] = newTime;
+        return true;
+    } else {
+        // Keep old time.
+        return false;
+    }
+}
+
+// Cooldown Expire Checker
+// This function checks to see if the saved time has expired or not.
+// Will return true if expired, and false if not yet expired.
+function cooldownExpireChecker(buttonID){
+    // Get current time in milliseconds
+    var dateNow = Date.now();
+
+    // Go look into cooldownSaved for this button. Save to var oldTime.
+    var savedTime = cooldownSaved[buttonID];
+
+    // If new time is bigger than oldTime resolve true, else false.
+    if(savedTime === undefined || dateNow > savedTime){
         return true;
     } else {
         // Keep old time.

--- a/lib/interactive/mixer-interactive.js
+++ b/lib/interactive/mixer-interactive.js
@@ -94,6 +94,10 @@ function mixerConnect(){
                     mixerClient.ready(true)
                     Grouper.startQueue();
                 },2000);
+            })
+            .catch(() => {
+                renderWindow.webContents.send('error', "Error readying Mixer board.")
+                return;
             });
                       
             console.log('Interactive Connected');


### PR DESCRIPTION
It seems like mixer either no longer requires rate limiting when getting user info from the chat api, or it's currently broken. This causes the auto grouper to always think we're being rate limited so it stops grouping people. This patch should fix that.

Also added sanity check for buttons. It piggybacks on the other cooldown code we wrote. If the save cooldown amount in the app has not yet expired, it will reject the promise and (hopefully) not fire. THIS NEEDS TESTED WITH AN AUTO CLICKER.

- Removed rate limit code from the auto grouper. 
- Added sanity check for buttons so they can't be pressed multiple times before cooldown hits.