### PR TITLE
Switch over to using board id number for filenames.

### DIFF
--- a/gui/app/templates/interactive/_interactive.html
+++ b/gui/app/templates/interactive/_interactive.html
@@ -1,7 +1,7 @@
 <!--Interactive Tab View-->
 <div class="content-block">
   <div ng-hide="getBoardNames().length == 0" class="content-block-header">
-    <span style="padding-left: 15px;font-weight: 600;font-size: 15px;" class="noselect">{{selectedBoard().name}}</span>
+    <span style="padding-left: 15px;font-weight: 600;font-size: 15px;" class="noselect">{{selectedBoard().name}} ({{selectedBoard().versionid}})</span>
     <span class="clickable board-settings-icon" ng-hide="selectedBoard() == null || selectedBoard() == ''" ng-click="showBoardSettingsModal()">
       <i class="fas fa-cog"></i>
     </span>


### PR DESCRIPTION
**Description:**
This change will make it so that we're using board id numbers instead of board names for our control filenames.

**Reason:**
We were running into issues with people changing the name of their board, and then losing all of their settings in Firebot. There were also cases of people naming their board things that did not work great with file systems.

**Warnings**
This will automatically convert all current controls files to this new file format. It will check when Firebot runs and then rename files from board name based files to version id based files. The end user shouldn't notice any changes within the app.

However, since we're renaming controls files there is the possibility of a bug that causes data loss that I didn't catch.
