### PR TITLE
Button thresholds with updating progress bars.

### DIFF
--- a/gui/app/templates/interactive/modals/editControlEffectsModal.html
+++ b/gui/app/templates/interactive/modals/editControlEffectsModal.html
@@ -23,6 +23,11 @@
        <input type="text" class="form-control" aria-describedby="basic-addon3" type="number" ng-model="control.cooldown">
      </div>
 
+     <div class="input-group settings-cooldown">
+      <span class="input-group-addon" id="basic-addon3">Threshold</span>
+      <input type="text" class="form-control" aria-describedby="basic-addon3" type="number" ng-model="control.threshold">
+    </div>
+
      <div class="controls-fb-inline">
         <label class="control-fb control--checkbox">Active Button
             <input type="checkbox" ng-model="control.active" aria-label="..." checked>

--- a/lib/common/mixer-interactive.js
+++ b/lib/common/mixer-interactive.js
@@ -458,7 +458,7 @@ function mixerDisconnect() {
 
     //clear Cooldowns
     Cooldowns.reset();
-    
+
     //clear thresholds
     Threshold.reset();
 

--- a/lib/common/mixer-interactive.js
+++ b/lib/common/mixer-interactive.js
@@ -5,6 +5,7 @@ const dataAccess = require('./data-access.js');
 const Controls = require('../interactive/control-router');
 const Grouper = require('../interactive/auto-grouper');
 const Cooldowns = require('../interactive/cooldowns.js');
+const Threshold = require('../interactive/threshold.js');
 const joystick = require('./handlers/game-controls/joystick');
 
 // Setup mixer Interactive and make it a global variable for use throughout the app.
@@ -457,6 +458,9 @@ function mixerDisconnect() {
 
     //clear Cooldowns
     Cooldowns.reset();
+    
+    //clear thresholds
+    Threshold.reset();
 
     // Send connection status to ui.
     renderWindow.webContents.send('connection', "Offline");

--- a/lib/common/mixer-interactive.js
+++ b/lib/common/mixer-interactive.js
@@ -427,6 +427,21 @@ function returnButton(buttonID, sceneID) {
     });
 }
 
+// Progress Updates
+// This will update the progress bar on a button.
+function progressUpdate(controlId, progress) {
+    // If we're online...
+    if (getInteractiveStatus()) {
+        returnButtonById(controlId).then((control) => {
+            // We just got a button... we just got a button... we just got a button... I wonder what it is?!
+            // Send control off to Mixer to update.
+            control.update({
+                progress: progress
+            });
+        });
+    }
+}
+
 // Disconnect from mixer
 // This disconnects the interactive connections.
 function mixerDisconnect() {
@@ -536,3 +551,4 @@ exports.getScenes = getScenes;
 exports.getInteractiveStatus = getInteractiveStatus;
 exports.getInteractiveCache = getInteractiveCache;
 exports.refreshInteractiveCache = refreshInteractiveCache;
+exports.progressUpdate = progressUpdate;

--- a/lib/interactive/control-router.js
+++ b/lib/interactive/control-router.js
@@ -3,6 +3,7 @@
 const {ipcMain} = require('electron');
 const mixerInteractive = require('../common/mixer-interactive');
 const cooldowns = require('./cooldowns.js');
+const threshold = require('./threshold.js');
 const sparkExemptManager = require('./helpers/sparkExemptManager.js');
 
 // Handlers
@@ -49,20 +50,31 @@ function controlRouter(mouseevent, mixerControls, mixerControl, gameJson, inputE
         cooldowns.router(mixerControls, mixerControl, firebot, control)
             // Process effects.
             .then(() => {
-                autoPlay(processEffectsRequest);
+                threshold.router(control)
+                    .then(() => {
+                        autoPlay(processEffectsRequest);
 
-                // Charge sparks for the button that was pressed.
-                if (inputEvent.transactionID) {
-                    // This will charge the user.
-                    if (!sparkExemptManager.userIsExempt(participant.username, participant.groupID)) {
-                        mixerInteractive.sparkTransaction(inputEvent.transactionID);
-                    }
-                }
+                        // Charge sparks for the button that was pressed.
+                        if (inputEvent.transactionID) {
+                            // This will charge the user.
+                            if (!sparkExemptManager.userIsExempt(participant.username, participant.groupID)) {
+                                mixerInteractive.sparkTransaction(inputEvent.transactionID);
+                            }
+                        }
 
-                // Throw this button info into UI log.
-                if (control.skipLog !== true) {
-                    renderWindow.webContents.send('eventlog', {username: participant.username, event: "pressed the " + controlID + " button."});
-                }
+                        // Throw this button info into UI log.
+                        if (control.skipLog !== true) {
+                            renderWindow.webContents.send('eventlog', {username: participant.username, event: "pressed the " + controlID + " button."});
+                        }
+                    })
+                    .catch(() => {
+                        console.log('Button has not passed its threshold. Ignoring button press.');
+
+                        // Throw this button info into UI log.
+                        if (control.skipLog !== true) {
+                            renderWindow.webContents.send('eventlog', {username: participant.username, event: "tried to press " + controlID + " but it has not passed its threshold."});
+                        }
+                    });
             })
             .catch(() => {
                 console.log('Button is still on cooldown. Ignoring button press.');

--- a/lib/interactive/threshold.js
+++ b/lib/interactive/threshold.js
@@ -1,0 +1,65 @@
+'use strict';
+const mixerInteractive = require('../common/mixer-interactive.js');
+
+// This var will save the threshhold status of all buttons.
+let thresholdSaved = [];
+
+// Progress Calculator
+function progressCalc(thresholdSaved, threshold) {
+    let progress = thresholdSaved / threshold;
+    return progress;
+}
+
+// Handles all threshold requests
+function thresholdRouter(control) {
+
+    return new Promise((resolve, reject) => {
+
+        let buttonId = control.controlId,
+            savedThreshold = thresholdSaved[buttonId],
+            controlThreshold = parseInt(control.threshold);
+
+        // Check to see if we have a control threshold saved for the control, if not we can just bypass everything.
+        if (controlThreshold !== 0 && controlThreshold !== null && controlThreshold !== undefined) {
+
+            // Check to see if we have a saved value to compare against, or if this is our first time hitting this control.
+            if (savedThreshold !== null && savedThreshold !== undefined) {
+                if (savedThreshold >= controlThreshold) {
+                    // We've passed the threshold
+                    thresholdSaved[buttonId] = 0;
+                    mixerInteractive.progressUpdate(buttonId, 0);
+                    resolve(true);
+                } else {
+                    // We're still trying to hit the threshold.
+                    thresholdSaved[buttonId] = thresholdSaved[buttonId] + 1;
+                    mixerInteractive.progressUpdate(buttonId, progressCalc(thresholdSaved[buttonId], controlThreshold));
+                    reject(false);
+                }
+            } else {
+                // We've not pushed any info to our saved thresholds yet. First time clicking the button.
+                if (controlThreshold === 1) {
+                    // Threshold is just set at one. So the user probably meant for it to fire on each click.
+                    resolve(true);
+                } else {
+                    // Threshold is set at more than one, so lets put in our first saved value.
+                    thresholdSaved[buttonId] = 1;
+                    mixerInteractive.progressUpdate(buttonId, progressCalc(thresholdSaved[buttonId], controlThreshold));
+                    reject(false);
+                }
+            }
+
+        } else {
+            // No threshold is set for this button. Go ahead and run it!
+            resolve(true);
+        }
+    });
+}
+
+// Clear Threshold
+function clearThreshold() {
+    thresholdSaved = [];
+}
+
+// Exports
+exports.router = thresholdRouter;
+exports.reset = clearThreshold;


### PR DESCRIPTION
This adds button thresholds with updating progress bars. 

- Threshold (number of uses) is set per button.
- Progress bar on Mixer front end updates live.
- Progress bar resets when button fires.
- Threshold check is skipped and button run if threshold is not entered or set to 0 or 1.
- Events logged in app if button not fired due to threshold check.
- Threshold counts are cleared on disconnect just like cooldowns.
- Manual button presses in app do not go through threshold checks.