### PR TITLE
Fixes spark exemptions.

### DIFF
--- a/gui/app/controllers/moderationController.js
+++ b/gui/app/controllers/moderationController.js
@@ -46,7 +46,7 @@
             // Exempt Group Functions
             $scope.exemptGroup = groupsService.getExemptGroup();
 
-            $scope.allViewerGroups = groupsService.getDefaultAndCustomViewerGroupNames();
+            $scope.allViewerGroups = groupsService.getDefaultAndCustomViewerGroupsForSparkExempt();
 
             $scope.newExemptUser = "";
             $scope.addUserToExemptGroup = function() {

--- a/gui/app/services/groupsService.js
+++ b/gui/app/services/groupsService.js
@@ -119,6 +119,14 @@
                 return service.getDefaultGroups().concat(service.getViewerGroupNames());
             };
 
+            // Returns all valid groups for spark exemption.
+            service.getDefaultAndCustomViewerGroupsForSparkExempt = function () {
+                // This removes the "Streamer" role because streamers are always spark exempt on their own channel.
+                let groups = service.getDefaultGroups(),
+                    groupsFixed = groups.filter(item => item !== 'Streamer');
+                return groupsFixed.concat(service.getViewerGroupNames());
+            };
+
             service.getDefaultGroups = function() {
                 return [
                     "Pro",

--- a/lib/interactive/control-router.js
+++ b/lib/interactive/control-router.js
@@ -90,18 +90,22 @@ function controlRouter(inputevent, mixerControls, mixerControl, gameJson, inputE
                                 if (control.skipLog !== true) {
                                     renderWindow.webContents.send('eventlog', {type: "general", username: participant.username, event: "tried to press " + controlID + " but it has not passed its threshold."});
                                 }
+                            })
+                            .then(() => {
+                                // Charge sparks for the button that was pressed.
+                                // Note this will fire even if the threshold hasnt passed. People pay to build up to the goal.
+                                if (inputEvent.transactionID) {
+                                    logger.debug("input event has transaction id, checking spark exempt status...");
+                                    // This will charge the user.
+                                    sparkExemptManager.userIsExempt(participant)
+                                        .then((exempt) => {
+                                            if (exempt === false) {
+                                                logger.debug(participant.username + " is not exempt, capturing transaction to charge sparks.");
+                                                mixerInteractive.sparkTransaction(inputEvent.transactionID);
+                                            }
+                                        });
+                                }
                             });
-
-                        // Charge sparks for the button that was pressed.
-                        // Note this will fire even if the threshold hasnt passed. People pay to build up to the goal.
-                        if (inputEvent.transactionID) {
-                            logger.debug("input event has transaction id, checking spark exempt status...");
-                            // This will charge the user.
-                            if (!sparkExemptManager.userIsExempt(participant.username, participant.groupID)) {
-                                logger.debug("Not exempt, capturing transaction to charge sparks.");
-                                mixerInteractive.sparkTransaction(inputEvent.transactionID);
-                            }
-                        }
                     })
                     .catch(() => {
                         logger.info('Button is still on cooldown. Ignoring button press.');

--- a/lib/interactive/helpers/sparkExemptManager.js
+++ b/lib/interactive/helpers/sparkExemptManager.js
@@ -3,61 +3,72 @@
 
 const {ipcMain} = require('electron');
 let settings = require("../../common/settings-access.js").settings;
-const groupsAccess = require('../../common/groups-access');
 const logger = require('../../logwrapper');
+const permissions = require("../permissions.js");
 
 let exemptUsers = [];
 let exemptGroups = [];
 let devExempt = ['Firebottle', 'ebiggz', 'ThePerry'];
 
-function userIsExempt(userName, mixerGroup) {
+function userIsExempt(participant) {
+    return new Promise((resolve) => {
+        let userName = participant.username;
 
-    if (userName != null && userName.trim().length < 1) {
-    // User name is empty. This shouldnt happen, but just to be safe.
-        return false;
-    }
+        if (userName != null && userName.trim().length < 1) {
+            // User name is empty. This shouldnt happen, but just to be safe.
+            logger.debug('Username is empty when checking spark exempt!');
+            resolve(false);
+        }
 
-    if (devExempt.includes(userName)) {
-        logger.info(`${userName} appears to be d-exempt. Not charging sparks.`);
-        // user is a dev.
-        return true;
-    }
+        // See if user is a dev.
+        if (devExempt.includes(userName)) {
+            logger.info(`${userName} appears to be d-exempt. Not charging sparks.`);
+            // user is a dev.
+            resolve(true);
+        }
 
-    if (exemptGroups.length === 0 && exemptUsers.length === 0) {
-    // Exempt groups and users arent being used. Dont even bother checking anything else.
-        return false;
-    }
+        // Exempt groups and users arent being used. Dont even bother checking anything else.
+        if (exemptGroups.length === 0 && exemptUsers.length === 0) {
+            logger.debug('No spark exempt users or groups to check against.');
+            resolve(false);
+        }
 
-    // get the custom groups for a user
-    let userGroups = groupsAccess.getGroupsForUser(userName).map((g) => {
-        return g.groupName;
+        // we have exempt usernames to check against.
+        if (exemptUsers.length > 0) {
+            if (exemptUsers.includes(userName)) {
+                // user is in the exempt user list!
+                logger.info(`${userName} is on exempt list. Not charging sparks. Exempt users: ${exemptUsers.join()}`);
+                resolve(true);
+            }
+        }
+
+        // If 'Default' is selected as spark exempt, that means no one should be charged sparks.
+        if (exemptGroups.includes('default')) {
+            logger.info('Default group is selected as spark exempt. Free buttons for everyone!');
+            resolve(true);
+        }
+
+        // Okay, now the hard part. Let's test to see if they're in an exempt group.
+        permissions.getUserRoles(participant)
+            .then((userRoles) => {
+                let combinedRoles = permissions.getCombinedRoles(participant.username, userRoles),
+                    exemptGroupMap = permissions.mapRoleNames(exemptGroups);
+
+                // Okay, if they passed then don't charge sparks.
+                if (permissions.userIsInRole(combinedRoles, exemptGroupMap)) {
+                    // user is in one or more of the exempt groups!
+                    logger.info(`${userName} is in an exempt group or is the owner. Not charging sparks. Exempt groups: ${exemptGroupMap}, user groups: ${combinedRoles}`);
+                    resolve(true);
+                } else {
+                    resolve(false);
+                }
+            })
+            .catch((err) => {
+                logger.error(err);
+                renderWindow.webContents.send('error', "There was an error trying to get user roles from chat for spark exemptions." + err);
+                resolve(false);
+            });
     });
-
-    if (mixerGroup != null && mixerGroup.trim().length < 1) {
-    // add the mixer group to the list, if it exists
-        userGroups.push(mixerGroup);
-    }
-
-    if (exemptGroups.length > 0 && userGroups.length > 0) {
-    // we have exempt groups
-        if (exemptGroups.some(g => userGroups.includes(g))) {
-            // user is in one or more of the exempt groups!
-            logger.info(`${userName} is in an exempt group. Not charging sparks. Exempt groups: ${exemptGroups.join()}, user groups: ${userGroups.join()}`);
-            return true;
-        }
-    }
-
-    if (exemptUsers.length > 0) {
-    // we have exempt users
-        if (exemptUsers.includes(userName)) {
-            // user is in the exempt user list!
-            logger.info(`${userName} is on exempt list. Not charging sparks. Exempt users: ${exemptUsers.join()}`);
-            return true;
-        }
-    }
-
-
-    return false;
 }
 
 function loadExemptList() {

--- a/lib/interactive/permissions.js
+++ b/lib/interactive/permissions.js
@@ -15,24 +15,30 @@ function userIsInRole(userRoles, approvedRoles) {
     }
 
     // Log which roles the user has and what we're checking for...
+    logger.debug('Checking roles for permissions or spark exempt.');
     logger.debug('User Roles:' + userRoles + ' | Looking for: ' + approvedRoles);
 
     // If the user is the owner, they have permission.
     if (userRoles.includes('Owner')) {
-        logger.debug('User is the owner! They have permission.');
+        logger.debug('User is the owner!');
         return true;
     }
 
     // Okay, let's check to see if the user has a matching role.
+    let roleMatch = false;
     userRoles.forEach((uRole) => {
         if (approvedRoles.includes(uRole)) {
-            logger.debug('Permissions Match: ' + uRole);
-            return true;
+            logger.debug('Role match! ' + uRole);
+            roleMatch = true;
         }
     });
 
+    if (roleMatch === true) {
+        return true;
+    }
+
     // If we get to here, the user does not have permission.
-    logger.debug('User does not have permission to his this button.');
+    logger.debug('User role check did not pass.');
     return false;
 }
 
@@ -157,3 +163,7 @@ function permissionsRouter(participant, control) {
 
 // Exports
 exports.router = permissionsRouter;
+exports.getUserRoles = getUserRoles;
+exports.userIsInRole = userIsInRole;
+exports.getCombinedRoles = getCombinedRoles;
+exports.mapRoleNames = mapRoleNames;


### PR DESCRIPTION
This should fix spark exemptions for most people.

Rewrote spark exemptions so that it no longer depends on the groups assigned to the active board. Now, spark exemptions use logic from our permissions code. It will pull information from Mixer for each interaction. 

One thing is that currently this change means we're checking the same info twice for interactive buttons. Once for permissions, and once for spark exempt. We can probably clean this up and make only one call instead. But, I don't think it'll be a problem for 99% of people since they won't hit rate limits.

Notes:
- To simplify things, streamers are no longer charged sparks in their own channels ever. 
- It no longer matters which groups are assigned to which scenes. You can give exempt status to groups no matter what.